### PR TITLE
feat(v2): add MaLoIdentModels.v2 namespace for api-electricity 2.0.0 (Konsultationsfassung)

### DIFF
--- a/MaLoIdentModels/MaLoIdentModels/JsonSettings/EmptyListToNullConverter.cs
+++ b/MaLoIdentModels/MaLoIdentModels/JsonSettings/EmptyListToNullConverter.cs
@@ -58,22 +58,8 @@ public class EmptyListToNullConverter<T> : JsonConverter<List<T>>
                 {
                     return string.IsNullOrWhiteSpace((string?)value);
                 }
-                if (value == null)
-                {
-                    return true;
-                }
-                var propertyType = property.PropertyType;
-                if (propertyType.IsClass || (propertyType.IsValueType && !propertyType.IsPrimitive))
-                {
-                    var method = typeof(EmptyListToNullConverter<T>).GetMethod(
-                        nameof(IsEmptyModel),
-                        System.Reflection.BindingFlags.NonPublic
-                            | System.Reflection.BindingFlags.Instance
-                    );
-                    var genericMethod = method?.MakeGenericMethod(propertyType);
-                    return (bool?)genericMethod?.Invoke(this, new[] { value }) ?? false;
-                }
-                return false;
+                // Non-null properties (value types, objects) mean the model has data.
+                return value == null;
             });
 
         return allChildPropertiesAreDefault;

--- a/MaLoIdentModels/MaLoIdentModels/JsonSettings/PercentLessHundredConverter.cs
+++ b/MaLoIdentModels/MaLoIdentModels/JsonSettings/PercentLessHundredConverter.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace MaLoIdentModels.JsonSettings;
+
+/// <summary>
+/// A JsonConverter that serializes decimal? to/from the EDI@Energy "percentLessHundred" string format.
+/// The wire format is a string matching the pattern ^\d{1,2}(\.\d{1,3})?$.
+/// We keep decimal? as the C# type for ergonomics and handle conversion transparently.
+/// </summary>
+public class PercentLessHundredConverter : JsonConverter<decimal?>
+{
+    public override decimal? Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options
+    )
+    {
+        if (reader.TokenType == JsonTokenType.Null)
+        {
+            return null;
+        }
+
+        var stringValue = reader.GetString();
+        if (string.IsNullOrWhiteSpace(stringValue))
+        {
+            return null;
+        }
+
+        return decimal.Parse(stringValue, CultureInfo.InvariantCulture);
+    }
+
+    public override void Write(Utf8JsonWriter writer, decimal? value, JsonSerializerOptions options)
+    {
+        if (value is null)
+        {
+            writer.WriteNullValue();
+            return;
+        }
+
+        // Normalize: remove trailing zeros but keep at most 3 decimal places
+        var rounded = Math.Round(value.Value, 3, MidpointRounding.AwayFromZero);
+        // G29 removes trailing zeros; we use InvariantCulture for '.' as decimal separator
+        var stringValue = rounded.ToString("G29", CultureInfo.InvariantCulture);
+        writer.WriteStringValue(stringValue);
+    }
+}

--- a/MaLoIdentModels/MaLoIdentModels/JsonSettings/PercentLessHundredConverter.cs
+++ b/MaLoIdentModels/MaLoIdentModels/JsonSettings/PercentLessHundredConverter.cs
@@ -42,6 +42,15 @@ public class PercentLessHundredConverter : JsonConverter<decimal?>
 
         // Normalize: remove trailing zeros but keep at most 3 decimal places
         var rounded = Math.Round(value.Value, 3, MidpointRounding.AwayFromZero);
+        if (rounded < 0 || rounded >= 100)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(value),
+                rounded,
+                "PercentLessHundred must be >= 0 and < 100."
+            );
+        }
+
         // G29 removes trailing zeros; we use InvariantCulture for '.' as decimal separator
         var stringValue = rounded.ToString("G29", CultureInfo.InvariantCulture);
         writer.WriteStringValue(stringValue);

--- a/MaLoIdentModels/MaLoIdentModels/Validation/PercentLessHundredValidationAttribute.cs
+++ b/MaLoIdentModels/MaLoIdentModels/Validation/PercentLessHundredValidationAttribute.cs
@@ -1,0 +1,45 @@
+namespace MaLoIdentModels.Validation;
+
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+
+/// <summary>
+/// Validates that a decimal? value fits the EDI@Energy "percentLessHundred" constraints:
+/// - Must be >= 0 and less than 100
+/// - Must have at most 3 decimal places
+/// Matches the anchored pattern ^\d{1,2}(\.\d{1,3})?$
+/// </summary>
+public class PercentLessHundredValidationAttribute : ValidationAttribute
+{
+    protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+    {
+        if (value is null)
+        {
+            return ValidationResult.Success;
+        }
+
+        if (value is not decimal decimalValue)
+        {
+            return new ValidationResult("Value must be a decimal.");
+        }
+
+        if (decimalValue < 0 || decimalValue >= 100)
+        {
+            return new ValidationResult(
+                $"Value must be >= 0 and < 100 but was '{decimalValue.ToString(CultureInfo.InvariantCulture)}'."
+            );
+        }
+
+        // Check at most 3 decimal places
+        var scaled = decimalValue * 1000;
+        if (scaled != Math.Floor(scaled))
+        {
+            return new ValidationResult(
+                $"Value must have at most 3 decimal places but was '{decimalValue.ToString(CultureInfo.InvariantCulture)}'."
+            );
+        }
+
+        return ValidationResult.Success;
+    }
+}

--- a/MaLoIdentModels/MaLoIdentModels/v1/DataControllableResource.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v1/DataControllableResource.cs
@@ -4,6 +4,7 @@ using System.Text.Json.Serialization;
 
 namespace MaLoIdentModels.v1;
 
+/// <seealso cref="v2.ControllableResource">v2 equivalent (ControllableResource)</seealso>
 public class DataControllableResource
 {
     [JsonIgnore]

--- a/MaLoIdentModels/MaLoIdentModels/v1/DataMarketLocation.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v1/DataMarketLocation.cs
@@ -4,6 +4,7 @@ using MaLoIdentModels.JsonSettings;
 
 namespace MaLoIdentModels.v1;
 
+/// <seealso cref="v2.MarketLocation">v2 equivalent (MarketLocation)</seealso>
 public class DataMarketLocation
 {
     [JsonIgnore]

--- a/MaLoIdentModels/MaLoIdentModels/v1/DataMarketLocationProperties.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v1/DataMarketLocationProperties.cs
@@ -4,6 +4,7 @@ using MaLoIdentModels.JsonSettings;
 
 namespace MaLoIdentModels.v1;
 
+/// <seealso cref="v2.MarketLocationCharacteristic">v2 equivalent (MarketLocationCharacteristic)</seealso>
 public class DataMarketLocationProperties
 {
     [JsonIgnore]

--- a/MaLoIdentModels/MaLoIdentModels/v1/DataMeterLocation.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v1/DataMeterLocation.cs
@@ -3,6 +3,7 @@ using System.Text.Json.Serialization;
 
 namespace MaLoIdentModels.v1;
 
+/// <seealso cref="v2.MeterLocation">v2 equivalent (MeterLocation)</seealso>
 public class DataMeterLocation
 {
     [JsonIgnore]

--- a/MaLoIdentModels/MaLoIdentModels/v1/DataNetworkLocation.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v1/DataNetworkLocation.cs
@@ -3,6 +3,7 @@ using System.Text.Json.Serialization;
 
 namespace MaLoIdentModels.v1;
 
+/// <seealso cref="v2.NetworkLocation">v2 equivalent (NetworkLocation)</seealso>
 public class DataNetworkLocation
 {
     [JsonIgnore]

--- a/MaLoIdentModels/MaLoIdentModels/v1/DataTechnicalResource.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v1/DataTechnicalResource.cs
@@ -2,6 +2,7 @@ using System.Text.Json.Serialization;
 
 namespace MaLoIdentModels.v1;
 
+/// <seealso cref="v2.TechnicalResource">v2 equivalent (TechnicalResource)</seealso>
 public class DataTechnicalResource
 {
     [JsonIgnore]

--- a/MaLoIdentModels/MaLoIdentModels/v1/DataTranche.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v1/DataTranche.cs
@@ -3,6 +3,7 @@ using System.Text.Json.Serialization;
 
 namespace MaLoIdentModels.v1;
 
+/// <seealso cref="v2.Tranche">v2 equivalent (Tranche)</seealso>
 public class DataTranche
 {
     [JsonIgnore]

--- a/MaLoIdentModels/MaLoIdentModels/v1/IdentificationParameter.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v1/IdentificationParameter.cs
@@ -5,6 +5,7 @@ using MaLoIdentModels.Validation;
 
 namespace MaLoIdentModels.v1;
 
+/// <seealso cref="v2.IdentificationParameter">v2 equivalent</seealso>
 public class IdentificationParameter
 {
     [JsonIgnore]

--- a/MaLoIdentModels/MaLoIdentModels/v1/IdentificationParameterIdentificationParameterAddress.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v1/IdentificationParameterIdentificationParameterAddress.cs
@@ -4,6 +4,7 @@ using MaLoIdentModels.JsonSettings;
 
 namespace MaLoIdentModels.v1;
 
+/// <seealso cref="v2.IdentificationParameterIdentificationParameterAddress">v2 equivalent</seealso>
 public class IdentificationParameterIdentificationParameterAddress
 {
     [JsonIgnore]

--- a/MaLoIdentModels/MaLoIdentModels/v1/IdentificationParameterIdentificationParameterId.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v1/IdentificationParameterIdentificationParameterId.cs
@@ -5,6 +5,7 @@ using MaLoIdentModels.JsonSettings;
 
 namespace MaLoIdentModels.v1;
 
+/// <seealso cref="v2.IdentificationParameterIdentificationParameterId">v2 equivalent</seealso>
 public class IdentificationParameterIdentificationParameterId
 {
     [JsonIgnore]

--- a/MaLoIdentModels/MaLoIdentModels/v1/MarketLocationDateTime.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v1/MarketLocationDateTime.cs
@@ -5,6 +5,7 @@ using MaLoIdentModels.JsonSettings;
 
 namespace MaLoIdentModels.v1;
 
+/// <seealso cref="v2.MarketLocationDateTime">v2 equivalent</seealso>
 public class MarketLocationDateTime
 {
     [JsonIgnore]

--- a/MaLoIdentModels/MaLoIdentModels/v1/MarketLocationMeasuringPointOperator.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v1/MarketLocationMeasuringPointOperator.cs
@@ -4,6 +4,7 @@ using MaLoIdentModels.JsonSettings;
 
 namespace MaLoIdentModels.v1;
 
+/// <seealso cref="v2.MarketLocationMeasuringPointOperator">v2 equivalent</seealso>
 public class MarketLocationMeasuringPointOperator
 {
     [JsonIgnore]

--- a/MaLoIdentModels/MaLoIdentModels/v1/MarketLocationNetworkOperator.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v1/MarketLocationNetworkOperator.cs
@@ -4,6 +4,7 @@ using MaLoIdentModels.JsonSettings;
 
 namespace MaLoIdentModels.v1;
 
+/// <seealso cref="v2.MarketLocationNetworkOperator">v2 equivalent</seealso>
 public class MarketLocationNetworkOperator
 {
     [JsonIgnore]

--- a/MaLoIdentModels/MaLoIdentModels/v1/MarketLocationProperties.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v1/MarketLocationProperties.cs
@@ -4,6 +4,7 @@ using MaLoIdentModels.JsonSettings;
 
 namespace MaLoIdentModels.v1;
 
+/// <seealso cref="v2.MarketLocationCharacteristic">v2 equivalent (MarketLocationCharacteristic)</seealso>
 public class MarketLocationProperties
 {
     [JsonIgnore]

--- a/MaLoIdentModels/MaLoIdentModels/v1/MarketLocationSupplier.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v1/MarketLocationSupplier.cs
@@ -4,6 +4,7 @@ using MaLoIdentModels.JsonSettings;
 
 namespace MaLoIdentModels.v1;
 
+/// <seealso cref="v2.MarketLocationSupplier">v2 equivalent</seealso>
 public class MarketLocationSupplier
 {
     [JsonIgnore]

--- a/MaLoIdentModels/MaLoIdentModels/v1/MarketLocationTransmissionSystemOperator.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v1/MarketLocationTransmissionSystemOperator.cs
@@ -4,6 +4,7 @@ using MaLoIdentModels.JsonSettings;
 
 namespace MaLoIdentModels.v1;
 
+/// <seealso cref="v2.MarketLocationTransmissionSystemOperator">v2 equivalent</seealso>
 public class MarketLocationTransmissionSystemOperator
 {
     [JsonIgnore]

--- a/MaLoIdentModels/MaLoIdentModels/v1/MeterLocationMeasuringPointOperator.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v1/MeterLocationMeasuringPointOperator.cs
@@ -4,6 +4,7 @@ using MaLoIdentModels.JsonSettings;
 
 namespace MaLoIdentModels.v1;
 
+/// <seealso cref="v2.MeterLocationMeasuringPointOperator">v2 equivalent</seealso>
 public class MeterLocationMeasuringPointOperator
 {
     [JsonIgnore]

--- a/MaLoIdentModels/MaLoIdentModels/v1/NetworkLocationMeasuringPointOperator.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v1/NetworkLocationMeasuringPointOperator.cs
@@ -4,6 +4,7 @@ using MaLoIdentModels.JsonSettings;
 
 namespace MaLoIdentModels.v1;
 
+/// <seealso cref="v2.NetworkLocationMeasuringPointOperator">v2 equivalent</seealso>
 public class NetworkLocationMeasuringPointOperator
 {
     [JsonIgnore]

--- a/MaLoIdentModels/MaLoIdentModels/v1/ResultNegative.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v1/ResultNegative.cs
@@ -3,6 +3,7 @@ using System.Text.Json.Serialization;
 
 namespace MaLoIdentModels.v1;
 
+/// <seealso cref="v2.ResultNegative">v2 equivalent</seealso>
 public class ResultNegative
 {
     [JsonIgnore]

--- a/MaLoIdentModels/MaLoIdentModels/v1/ResultPositive.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v1/ResultPositive.cs
@@ -5,6 +5,7 @@ using MaLoIdentModels.JsonSettings;
 
 namespace MaLoIdentModels.v1;
 
+/// <seealso cref="v2.ResultPositive">v2 equivalent</seealso>
 public class ResultPositive
 {
     [JsonIgnore]

--- a/MaLoIdentModels/MaLoIdentModels/v1/SrMarketPartner.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v1/SrMarketPartner.cs
@@ -4,6 +4,7 @@ using MaLoIdentModels.JsonSettings;
 
 namespace MaLoIdentModels.v1;
 
+/// <seealso cref="v2.ControllableResourceMeasuringPointOperator">v2 equivalent (ControllableResourceMeasuringPointOperator)</seealso>
 public class SrMarketPartner
 {
     [JsonIgnore]

--- a/MaLoIdentModels/MaLoIdentModels/v1/TrancheSupplier.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v1/TrancheSupplier.cs
@@ -3,6 +3,7 @@ using System.Text.Json.Serialization;
 
 namespace MaLoIdentModels.v1;
 
+/// <seealso cref="v2.TrancheSupplier">v2 equivalent</seealso>
 public class TrancheSupplier
 {
     [JsonIgnore]

--- a/MaLoIdentModels/MaLoIdentModels/v2/Address.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/Address.cs
@@ -23,7 +23,7 @@ public class Address
     public string? Street { get; set; }
 
     [JsonPropertyName("houseNumber")]
-    public int HouseNumber { get; set; }
+    public int? HouseNumber { get; set; }
 
     [JsonPropertyName("houseNumberAddition")]
     public string? HouseNumberAddition { get; set; }

--- a/MaLoIdentModels/MaLoIdentModels/v2/Address.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/Address.cs
@@ -10,7 +10,7 @@ public class Address
     public System.Guid? Id { get; set; }
 
     [JsonPropertyName("countryCode")]
-    [RegularExpression(@"[A-Z]{2}")]
+    [RegularExpression(@"^[A-Z]{2}$")] // anchors added; spec pattern is unanchored: https://github.com/EDI-Energy/api-electricity/issues/46
     public string? CountryCode { get; set; }
 
     [JsonPropertyName("zipCode")]

--- a/MaLoIdentModels/MaLoIdentModels/v2/Address.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/Address.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace MaLoIdentModels.v2;
+
+public class Address
+{
+    [JsonIgnore]
+    [Key]
+    public System.Guid? Id { get; set; }
+
+    [JsonPropertyName("countryCode")]
+    [RegularExpression(@"[A-Z]{2}")]
+    public string? CountryCode { get; set; }
+
+    [JsonPropertyName("zipCode")]
+    public string? ZipCode { get; set; }
+
+    [JsonPropertyName("city")]
+    public string? City { get; set; }
+
+    [JsonPropertyName("street")]
+    public string? Street { get; set; }
+
+    [JsonPropertyName("houseNumber")]
+    public int HouseNumber { get; set; }
+
+    [JsonPropertyName("houseNumberAddition")]
+    public string? HouseNumberAddition { get; set; }
+}

--- a/MaLoIdentModels/MaLoIdentModels/v2/ControllableResource.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/ControllableResource.cs
@@ -3,6 +3,7 @@ using System.Text.Json.Serialization;
 
 namespace MaLoIdentModels.v2;
 
+/// <seealso cref="v1.DataControllableResource">v1 equivalent (DataControllableResource)</seealso>
 public class ControllableResource
 {
     [JsonIgnore]
@@ -10,8 +11,8 @@ public class ControllableResource
     public System.Guid? Id { get; set; }
 
     /// <summary>
-    /// The controllable resource identifier. The JSON name uses the spec's typo
-    /// <c>identifierControllableRessource</c> (double 's') for wire compatibility.
+    /// The controllable resource identifier. Was <see cref="v1.DataControllableResource.SrId"/> in v1.
+    /// The JSON name uses the spec's typo <c>identifierControllableRessource</c> (double 's') for wire compatibility.
     /// The C# property uses the correct English spelling.
     /// </summary>
     [JsonPropertyName("identifierControllableRessource")]

--- a/MaLoIdentModels/MaLoIdentModels/v2/ControllableResource.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/ControllableResource.cs
@@ -9,6 +9,11 @@ public class ControllableResource
     [System.ComponentModel.DataAnnotations.Key]
     public System.Guid? Id { get; set; }
 
+    /// <summary>
+    /// The controllable resource identifier. The JSON name uses the spec's typo
+    /// <c>identifierControllableRessource</c> (double 's') for wire compatibility.
+    /// The C# property uses the correct English spelling.
+    /// </summary>
     [JsonPropertyName("identifierControllableRessource")]
     public string? IdentifierControllableResource { get; set; }
 

--- a/MaLoIdentModels/MaLoIdentModels/v2/ControllableResource.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/ControllableResource.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace MaLoIdentModels.v2;
+
+public class ControllableResource
+{
+    [JsonIgnore]
+    [System.ComponentModel.DataAnnotations.Key]
+    public System.Guid? Id { get; set; }
+
+    [JsonPropertyName("identifierControllableRessource")]
+    public string? IdentifierControllableResource { get; set; }
+
+    [JsonPropertyName("controllableResourceMeasuringPointOperators")]
+    public List<ControllableResourceMeasuringPointOperator>? ControllableResourceMeasuringPointOperators { get; set; }
+}

--- a/MaLoIdentModels/MaLoIdentModels/v2/ControllableResourceMeasuringPointOperator.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/ControllableResourceMeasuringPointOperator.cs
@@ -4,6 +4,7 @@ using MaLoIdentModels.JsonSettings;
 
 namespace MaLoIdentModels.v2;
 
+/// <seealso cref="v1.SrMarketPartner">v1 equivalent (SrMarketPartner)</seealso>
 public class ControllableResourceMeasuringPointOperator
 {
     [JsonIgnore]

--- a/MaLoIdentModels/MaLoIdentModels/v2/ControllableResourceMeasuringPointOperator.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/ControllableResourceMeasuringPointOperator.cs
@@ -10,6 +10,10 @@ public class ControllableResourceMeasuringPointOperator
     [System.ComponentModel.DataAnnotations.Key]
     public Guid? Id { get; set; }
 
+    /// <summary>
+    /// The 13-digit market partner ID. Serialized as <c>identifierMeasuringPointOperator</c> on the wire.
+    /// The spec uses <c>string</c> with pattern <c>^\d{13}$</c>, but we keep <c>long</c> for type safety.
+    /// </summary>
     [JsonPropertyName("identifierMeasuringPointOperator")]
     public long MarketPartnerId { get; set; }
 

--- a/MaLoIdentModels/MaLoIdentModels/v2/ControllableResourceMeasuringPointOperator.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/ControllableResourceMeasuringPointOperator.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Text.Json.Serialization;
+using MaLoIdentModels.JsonSettings;
+
+namespace MaLoIdentModels.v2;
+
+public class ControllableResourceMeasuringPointOperator
+{
+    [JsonIgnore]
+    [System.ComponentModel.DataAnnotations.Key]
+    public Guid? Id { get; set; }
+
+    [JsonPropertyName("identifierMeasuringPointOperator")]
+    public long MarketPartnerId { get; set; }
+
+    [JsonConverter(typeof(DateTimeOffsetWithTrailingZConverter))]
+    [JsonPropertyName("executionTimeFrom")]
+    public DateTimeOffset ExecutionTimeFrom { get; set; }
+
+    [JsonConverter(typeof(NullableDateTimeOffsetWithTrailingZConverter))]
+    [JsonPropertyName("executionTimeUntil")]
+    public DateTimeOffset? ExecutionTimeUntil { get; set; }
+}

--- a/MaLoIdentModels/MaLoIdentModels/v2/ControllableResourceMeasuringPointOperator.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/ControllableResourceMeasuringPointOperator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 using MaLoIdentModels.JsonSettings;
 
@@ -8,15 +9,16 @@ namespace MaLoIdentModels.v2;
 public class ControllableResourceMeasuringPointOperator
 {
     [JsonIgnore]
-    [System.ComponentModel.DataAnnotations.Key]
+    [Key]
     public Guid? Id { get; set; }
 
     /// <summary>
-    /// The 13-digit market partner ID. Serialized as <c>identifierMeasuringPointOperator</c> on the wire.
-    /// The spec uses <c>string</c> with pattern <c>^\d{13}$</c>, but we keep <c>long</c> for type safety.
+    /// 13-digit market partner ID as string per v2 spec.
+    /// Serialized as <c>identifierMeasuringPointOperator</c> on the wire.
     /// </summary>
     [JsonPropertyName("identifierMeasuringPointOperator")]
-    public long MarketPartnerId { get; set; }
+    [RegularExpression(@"^\d{13}$")]
+    public string? MarketPartnerId { get; set; }
 
     [JsonConverter(typeof(DateTimeOffsetWithTrailingZConverter))]
     [JsonPropertyName("executionTimeFrom")]

--- a/MaLoIdentModels/MaLoIdentModels/v2/EnergyDirection.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/EnergyDirection.cs
@@ -1,0 +1,15 @@
+using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+
+namespace MaLoIdentModels.v2;
+
+public enum EnergyDirection
+{
+    [EnumMember(Value = "consumption")]
+    [JsonStringEnumMemberName("consumption")]
+    Consumption,
+
+    [EnumMember(Value = "production")]
+    [JsonStringEnumMemberName("production")]
+    Production,
+}

--- a/MaLoIdentModels/MaLoIdentModels/v2/GeographicCoordinates.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/GeographicCoordinates.cs
@@ -1,0 +1,39 @@
+using System.Text.Json.Serialization;
+using MaLoIdentModels.JsonSettings;
+
+namespace MaLoIdentModels.v2;
+
+public class GeographicCoordinates
+{
+    [JsonIgnore]
+    [System.ComponentModel.DataAnnotations.Key]
+    public System.Guid? Id { get; set; }
+
+    [JsonConverter(typeof(EmptyStringConverter))]
+    [JsonPropertyName("latitude")]
+    public string? Latitude { get; set; }
+
+    [JsonConverter(typeof(EmptyStringConverter))]
+    [JsonPropertyName("longitude")]
+    public string? Longitude { get; set; }
+
+    [JsonConverter(typeof(EmptyStringConverter))]
+    [JsonPropertyName("east")]
+    public string? East { get; set; }
+
+    [JsonConverter(typeof(EmptyStringConverter))]
+    [JsonPropertyName("north")]
+    public string? North { get; set; }
+
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonPropertyName("zone")]
+    public Zone? Zone { get; set; }
+
+    [JsonConverter(typeof(EmptyStringConverter))]
+    [JsonPropertyName("northing")]
+    public string? Northing { get; set; }
+
+    [JsonConverter(typeof(EmptyStringConverter))]
+    [JsonPropertyName("easting")]
+    public string? Easting { get; set; }
+}

--- a/MaLoIdentModels/MaLoIdentModels/v2/IdentificationParameter.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/IdentificationParameter.cs
@@ -5,6 +5,7 @@ using MaLoIdentModels.Validation;
 
 namespace MaLoIdentModels.v2;
 
+/// <seealso cref="v1.IdentificationParameter">v1 equivalent</seealso>
 public class IdentificationParameter
 {
     [JsonIgnore]

--- a/MaLoIdentModels/MaLoIdentModels/v2/IdentificationParameter.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/IdentificationParameter.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Text.Json.Serialization;
+using MaLoIdentModels.JsonSettings;
+using MaLoIdentModels.Validation;
+
+namespace MaLoIdentModels.v2;
+
+public class IdentificationParameter
+{
+    [JsonIgnore]
+    [System.ComponentModel.DataAnnotations.Key]
+    public Guid? Id { get; set; }
+
+    /// <remarks>
+    /// Has to be midnight in German local time.
+    /// See Seite 6 von 111
+    /// 1.1.2 SD: Ermittlung der MaLo-ID der Marktlokation
+    /// https://www.bundesnetzagentur.de/DE/Beschlusskammern/1_GZ/BK6-GZ/2022/BK6-22-024/Beschluss/Anlage1b_GPKE_Teil2.pdf?__blob=publicationFile&amp;v=1
+    /// </remarks>
+    [GermanMidnightValidation]
+    [JsonConverter(typeof(DateTimeOffsetWithTrailingZConverter))]
+    [JsonPropertyName("identificationDateTime")]
+    public DateTimeOffset IdentificationDateTime { get; set; }
+
+    [JsonPropertyName("energyDirection")]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public EnergyDirection EnergyDirection { get; set; }
+
+    [JsonPropertyName("identificationParameterId")]
+    public IdentificationParameterIdentificationParameterId? IdentificationParameterId { get; set; }
+
+    [JsonPropertyName("identificationParameterAddress")]
+    public IdentificationParameterIdentificationParameterAddress? IdentificationParameterAddress { get; set; }
+}

--- a/MaLoIdentModels/MaLoIdentModels/v2/IdentificationParameterIdentificationParameterAddress.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/IdentificationParameterIdentificationParameterAddress.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using MaLoIdentModels.JsonSettings;
+
+namespace MaLoIdentModels.v2;
+
+public class IdentificationParameterIdentificationParameterAddress
+{
+    [JsonIgnore]
+    [System.ComponentModel.DataAnnotations.Key]
+    public System.Guid? Id { get; set; }
+
+    [JsonPropertyName("name")]
+    public Name? Name { get; set; }
+
+    [JsonPropertyName("address")]
+    public Address? Address { get; set; }
+
+    [JsonConverter(typeof(EmptyListToNullConverter<LandParcel>))]
+    [JsonPropertyName("landParcels")]
+    public List<LandParcel>? LandParcels { get; set; }
+
+    [JsonPropertyName("geographicCoordinates")]
+    public GeographicCoordinates? GeographicCoordinates { get; set; }
+}

--- a/MaLoIdentModels/MaLoIdentModels/v2/IdentificationParameterIdentificationParameterAddress.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/IdentificationParameterIdentificationParameterAddress.cs
@@ -4,6 +4,7 @@ using MaLoIdentModels.JsonSettings;
 
 namespace MaLoIdentModels.v2;
 
+/// <seealso cref="v1.IdentificationParameterIdentificationParameterAddress">v1 equivalent</seealso>
 public class IdentificationParameterIdentificationParameterAddress
 {
     [JsonIgnore]

--- a/MaLoIdentModels/MaLoIdentModels/v2/IdentificationParameterIdentificationParameterId.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/IdentificationParameterIdentificationParameterId.cs
@@ -5,20 +5,30 @@ using MaLoIdentModels.JsonSettings;
 
 namespace MaLoIdentModels.v2;
 
+/// <seealso cref="v1.IdentificationParameterIdentificationParameterId">v1 equivalent</seealso>
 public class IdentificationParameterIdentificationParameterId
 {
     [JsonIgnore]
     [Key]
     public System.Guid? Id { get; set; }
 
+    /// <summary>
+    /// Was <see cref="v1.IdentificationParameterIdentificationParameterId.MaloId"/> in v1.
+    /// </summary>
     [JsonConverter(typeof(EmptyStringConverter))]
     [JsonPropertyName("identifierMarketLocation")]
     public string? IdentifierMarketLocation { get; set; }
 
+    /// <summary>
+    /// Was <see cref="v1.IdentificationParameterIdentificationParameterId.TranchenIds"/> in v1.
+    /// </summary>
     [JsonConverter(typeof(EmptyListToNullConverter<string>))]
     [JsonPropertyName("identifierMarketTranches")]
     public List<string>? IdentifierMarketTranches { get; set; }
 
+    /// <summary>
+    /// Was <see cref="v1.IdentificationParameterIdentificationParameterId.MeloIds"/> in v1.
+    /// </summary>
     [JsonConverter(typeof(EmptyListToNullConverter<string>))]
     [JsonPropertyName("identifierMeterLocations")]
     public List<string>? IdentifierMeterLocations { get; set; }

--- a/MaLoIdentModels/MaLoIdentModels/v2/IdentificationParameterIdentificationParameterId.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/IdentificationParameterIdentificationParameterId.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+using MaLoIdentModels.JsonSettings;
+
+namespace MaLoIdentModels.v2;
+
+public class IdentificationParameterIdentificationParameterId
+{
+    [JsonIgnore]
+    [Key]
+    public System.Guid? Id { get; set; }
+
+    [JsonConverter(typeof(EmptyStringConverter))]
+    [JsonPropertyName("identifierMarketLocation")]
+    public string? IdentifierMarketLocation { get; set; }
+
+    [JsonConverter(typeof(EmptyListToNullConverter<string>))]
+    [JsonPropertyName("identifierMarketTranches")]
+    public List<string>? IdentifierMarketTranches { get; set; }
+
+    [JsonConverter(typeof(EmptyListToNullConverter<string>))]
+    [JsonPropertyName("identifierMeterLocations")]
+    public List<string>? IdentifierMeterLocations { get; set; }
+
+    [JsonConverter(typeof(EmptyListToNullConverter<string>))]
+    [JsonPropertyName("meterNumbers")]
+    public List<string>? MeterNumbers { get; set; }
+
+    [JsonConverter(typeof(EmptyStringConverter))]
+    [JsonPropertyName("customerNumber")]
+    public string? CustomerNumber { get; set; }
+}

--- a/MaLoIdentModels/MaLoIdentModels/v2/LandParcel.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/LandParcel.cs
@@ -1,0 +1,19 @@
+using System.Text.Json.Serialization;
+
+namespace MaLoIdentModels.v2;
+
+public class LandParcel
+{
+    [JsonIgnore]
+    [System.ComponentModel.DataAnnotations.Key]
+    public System.Guid? Id { get; set; }
+
+    [JsonPropertyName("districtName")]
+    public string? DistrictName { get; set; }
+
+    [JsonPropertyName("lotNumber")]
+    public string? LotNumber { get; set; }
+
+    [JsonPropertyName("subLotNumber")]
+    public string? SubLotNumber { get; set; }
+}

--- a/MaLoIdentModels/MaLoIdentModels/v2/LandParcel.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/LandParcel.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using MaLoIdentModels.JsonSettings;
 
 namespace MaLoIdentModels.v2;
 
@@ -8,12 +9,15 @@ public class LandParcel
     [System.ComponentModel.DataAnnotations.Key]
     public System.Guid? Id { get; set; }
 
+    [JsonConverter(typeof(EmptyStringConverter))]
     [JsonPropertyName("districtName")]
     public string? DistrictName { get; set; }
 
+    [JsonConverter(typeof(EmptyStringConverter))]
     [JsonPropertyName("lotNumber")]
     public string? LotNumber { get; set; }
 
+    [JsonConverter(typeof(EmptyStringConverter))]
     [JsonPropertyName("subLotNumber")]
     public string? SubLotNumber { get; set; }
 }

--- a/MaLoIdentModels/MaLoIdentModels/v2/MarketLocation.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/MarketLocation.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using MaLoIdentModels.JsonSettings;
+
+namespace MaLoIdentModels.v2;
+
+public class MarketLocation
+{
+    [JsonIgnore]
+    [System.ComponentModel.DataAnnotations.Key]
+    public System.Guid? Id { get; set; }
+
+    [JsonPropertyName("identifierMarketLocation")]
+    public string? IdentifierMarketLocation { get; set; }
+
+    [JsonPropertyName("energyDirection")]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public EnergyDirection EnergyDirection { get; set; }
+
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonPropertyName("measurementTechnologyClassification")]
+    public MeasurementTechnologyClassification MeasurementTechnologyClassification { get; set; }
+
+    [JsonPropertyName("characteristics")]
+    public List<MarketLocationCharacteristic>? Characteristics { get; set; }
+
+    [JsonPropertyName("networkOperators")]
+    public List<MarketLocationNetworkOperator>? NetworkOperators { get; set; }
+
+    [JsonConverter(typeof(EmptyListToNullConverter<MarketLocationMeasuringPointOperator>))]
+    [JsonPropertyName("measuringPointOperators")]
+    public List<MarketLocationMeasuringPointOperator>? MeasuringPointOperators { get; set; }
+
+    [JsonPropertyName("transmissionSystemOperators")]
+    public List<MarketLocationTransmissionSystemOperator>? TransmissionSystemOperators { get; set; }
+
+    [JsonConverter(typeof(EmptyListToNullConverter<MarketLocationSupplier>))]
+    [JsonPropertyName("suppliers")]
+    public List<MarketLocationSupplier>? Suppliers { get; set; }
+
+    [JsonPropertyName("name")]
+    public Name? Name { get; set; }
+
+    [JsonPropertyName("address")]
+    public Address? Address { get; set; }
+
+    [JsonConverter(typeof(EmptyListToNullConverter<LandParcel>))]
+    [JsonPropertyName("landParcels")]
+    public List<LandParcel>? LandParcels { get; set; }
+
+    [JsonPropertyName("geographicCoordinates")]
+    public GeographicCoordinates? GeographicCoordinates { get; set; }
+}

--- a/MaLoIdentModels/MaLoIdentModels/v2/MarketLocation.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/MarketLocation.cs
@@ -21,9 +21,11 @@ public class MarketLocation
     [JsonPropertyName("measurementTechnologyClassification")]
     public MeasurementTechnologyClassification MeasurementTechnologyClassification { get; set; }
 
+    [JsonConverter(typeof(EmptyListToNullConverter<MarketLocationCharacteristic>))]
     [JsonPropertyName("characteristics")]
     public List<MarketLocationCharacteristic>? Characteristics { get; set; }
 
+    [JsonConverter(typeof(EmptyListToNullConverter<MarketLocationNetworkOperator>))]
     [JsonPropertyName("networkOperators")]
     public List<MarketLocationNetworkOperator>? NetworkOperators { get; set; }
 
@@ -31,6 +33,7 @@ public class MarketLocation
     [JsonPropertyName("measuringPointOperators")]
     public List<MarketLocationMeasuringPointOperator>? MeasuringPointOperators { get; set; }
 
+    [JsonConverter(typeof(EmptyListToNullConverter<MarketLocationTransmissionSystemOperator>))]
     [JsonPropertyName("transmissionSystemOperators")]
     public List<MarketLocationTransmissionSystemOperator>? TransmissionSystemOperators { get; set; }
 

--- a/MaLoIdentModels/MaLoIdentModels/v2/MarketLocation.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/MarketLocation.cs
@@ -4,12 +4,19 @@ using MaLoIdentModels.JsonSettings;
 
 namespace MaLoIdentModels.v2;
 
+/// <summary>
+/// The market location entity in a positive identification result.
+/// </summary>
+/// <seealso cref="v1.DataMarketLocation">v1 equivalent (DataMarketLocation)</seealso>
 public class MarketLocation
 {
     [JsonIgnore]
     [System.ComponentModel.DataAnnotations.Key]
     public System.Guid? Id { get; set; }
 
+    /// <summary>
+    /// The market location identifier. Was <see cref="v1.DataMarketLocation.MaloId"/> in v1.
+    /// </summary>
     [JsonPropertyName("identifierMarketLocation")]
     public string? IdentifierMarketLocation { get; set; }
 
@@ -21,6 +28,9 @@ public class MarketLocation
     [JsonPropertyName("measurementTechnologyClassification")]
     public MeasurementTechnologyClassification MeasurementTechnologyClassification { get; set; }
 
+    /// <summary>
+    /// Was <see cref="v1.DataMarketLocation.DataMarketLocationProperties"/> in v1.
+    /// </summary>
     [JsonConverter(typeof(EmptyListToNullConverter<MarketLocationCharacteristic>))]
     [JsonPropertyName("characteristics")]
     public List<MarketLocationCharacteristic>? Characteristics { get; set; }

--- a/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationCharacteristic.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationCharacteristic.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Text.Json.Serialization;
+using MaLoIdentModels.JsonSettings;
+
+namespace MaLoIdentModels.v2;
+
+public class MarketLocationCharacteristic
+{
+    [JsonIgnore]
+    [System.ComponentModel.DataAnnotations.Key]
+    public Guid? Id { get; set; }
+
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonPropertyName("marketLocationProperty")]
+    public MarketLocationProperty MarketLocationProperty { get; set; }
+
+    [JsonConverter(typeof(DateTimeOffsetWithTrailingZConverter))]
+    [JsonPropertyName("executionTimeFrom")]
+    public DateTimeOffset ExecutionTimeFrom { get; set; }
+
+    [JsonConverter(typeof(NullableDateTimeOffsetWithTrailingZConverter))]
+    [JsonPropertyName("executionTimeUntil")]
+    public DateTimeOffset? ExecutionTimeUntil { get; set; }
+}

--- a/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationCharacteristic.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationCharacteristic.cs
@@ -4,6 +4,7 @@ using MaLoIdentModels.JsonSettings;
 
 namespace MaLoIdentModels.v2;
 
+/// <seealso cref="v1.MarketLocationProperties">v1 equivalent (MarketLocationProperties)</seealso>
 public class MarketLocationCharacteristic
 {
     [JsonIgnore]

--- a/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationDateTime.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationDateTime.cs
@@ -11,9 +11,9 @@ public class MarketLocationDateTime
     [Key]
     public Guid? Id { get; set; }
 
-    [JsonPropertyName("maloId")]
+    [JsonPropertyName("identifierMarketLocation")]
     [RegularExpression(@"\d{11}")]
-    public string? MaloId { get; set; }
+    public string? IdentifierMarketLocation { get; set; }
 
     [JsonConverter(typeof(DateTimeOffsetWithTrailingZConverter))]
     [JsonPropertyName("executionTimeFrom")]

--- a/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationDateTime.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationDateTime.cs
@@ -5,12 +5,16 @@ using MaLoIdentModels.JsonSettings;
 
 namespace MaLoIdentModels.v2;
 
+/// <seealso cref="v1.MarketLocationDateTime">v1 equivalent</seealso>
 public class MarketLocationDateTime
 {
     [JsonIgnore]
     [Key]
     public Guid? Id { get; set; }
 
+    /// <summary>
+    /// Was <see cref="v1.MarketLocationDateTime.MaloId"/> in v1.
+    /// </summary>
     [JsonPropertyName("identifierMarketLocation")]
     [RegularExpression(@"\d{11}")]
     public string? IdentifierMarketLocation { get; set; }

--- a/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationDateTime.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationDateTime.cs
@@ -1,0 +1,25 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+using MaLoIdentModels.JsonSettings;
+
+namespace MaLoIdentModels.v2;
+
+public class MarketLocationDateTime
+{
+    [JsonIgnore]
+    [Key]
+    public Guid? Id { get; set; }
+
+    [JsonPropertyName("maloId")]
+    [RegularExpression(@"\d{11}")]
+    public string? MaloId { get; set; }
+
+    [JsonConverter(typeof(DateTimeOffsetWithTrailingZConverter))]
+    [JsonPropertyName("executionTimeFrom")]
+    public DateTimeOffset ExecutionTimeFrom { get; set; }
+
+    [JsonConverter(typeof(NullableDateTimeOffsetWithTrailingZConverter))]
+    [JsonPropertyName("executionTimeUntil")]
+    public DateTimeOffset? ExecutionTimeUntil { get; set; }
+}

--- a/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationDateTime.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationDateTime.cs
@@ -16,7 +16,7 @@ public class MarketLocationDateTime
     /// Was <see cref="v1.MarketLocationDateTime.MaloId"/> in v1.
     /// </summary>
     [JsonPropertyName("identifierMarketLocation")]
-    [RegularExpression(@"\d{11}")]
+    [RegularExpression(@"^\d{11}$")] // anchors added; spec pattern is unanchored: https://github.com/EDI-Energy/api-electricity/issues/46
     public string? IdentifierMarketLocation { get; set; }
 
     [JsonConverter(typeof(DateTimeOffsetWithTrailingZConverter))]

--- a/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationMeasuringPointOperator.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationMeasuringPointOperator.cs
@@ -10,6 +10,10 @@ public class MarketLocationMeasuringPointOperator
     [System.ComponentModel.DataAnnotations.Key]
     public Guid? Id { get; set; }
 
+    /// <summary>
+    /// The 13-digit market partner ID. Serialized as <c>identifierMeasuringPointOperator</c> on the wire.
+    /// The spec uses <c>string</c> with pattern <c>^\d{13}$</c>, but we keep <c>long</c> for type safety.
+    /// </summary>
     [JsonPropertyName("identifierMeasuringPointOperator")]
     public long MarketPartnerId { get; set; }
 

--- a/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationMeasuringPointOperator.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationMeasuringPointOperator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 using MaLoIdentModels.JsonSettings;
 
@@ -8,15 +9,16 @@ namespace MaLoIdentModels.v2;
 public class MarketLocationMeasuringPointOperator
 {
     [JsonIgnore]
-    [System.ComponentModel.DataAnnotations.Key]
+    [Key]
     public Guid? Id { get; set; }
 
     /// <summary>
-    /// The 13-digit market partner ID. Serialized as <c>identifierMeasuringPointOperator</c> on the wire.
-    /// The spec uses <c>string</c> with pattern <c>^\d{13}$</c>, but we keep <c>long</c> for type safety.
+    /// 13-digit market partner ID as string per v2 spec.
+    /// Serialized as <c>identifierMeasuringPointOperator</c> on the wire.
     /// </summary>
     [JsonPropertyName("identifierMeasuringPointOperator")]
-    public long MarketPartnerId { get; set; }
+    [RegularExpression(@"^\d{13}$")]
+    public string? MarketPartnerId { get; set; }
 
     [JsonConverter(typeof(DateTimeOffsetWithTrailingZConverter))]
     [JsonPropertyName("executionTimeFrom")]

--- a/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationMeasuringPointOperator.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationMeasuringPointOperator.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Text.Json.Serialization;
+using MaLoIdentModels.JsonSettings;
+
+namespace MaLoIdentModels.v2;
+
+public class MarketLocationMeasuringPointOperator
+{
+    [JsonIgnore]
+    [System.ComponentModel.DataAnnotations.Key]
+    public Guid? Id { get; set; }
+
+    [JsonPropertyName("identifierMeasuringPointOperator")]
+    public long MarketPartnerId { get; set; }
+
+    [JsonConverter(typeof(DateTimeOffsetWithTrailingZConverter))]
+    [JsonPropertyName("executionTimeFrom")]
+    public DateTimeOffset ExecutionTimeFrom { get; set; }
+
+    [JsonConverter(typeof(NullableDateTimeOffsetWithTrailingZConverter))]
+    [JsonPropertyName("executionTimeUntil")]
+    public DateTimeOffset? ExecutionTimeUntil { get; set; }
+}

--- a/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationMeasuringPointOperator.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationMeasuringPointOperator.cs
@@ -4,6 +4,7 @@ using MaLoIdentModels.JsonSettings;
 
 namespace MaLoIdentModels.v2;
 
+/// <seealso cref="v1.MarketLocationMeasuringPointOperator">v1 equivalent</seealso>
 public class MarketLocationMeasuringPointOperator
 {
     [JsonIgnore]

--- a/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationNetworkOperator.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationNetworkOperator.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Text.Json.Serialization;
+using MaLoIdentModels.JsonSettings;
+
+namespace MaLoIdentModels.v2;
+
+public class MarketLocationNetworkOperator
+{
+    [JsonIgnore]
+    [System.ComponentModel.DataAnnotations.Key]
+    public Guid? Id { get; set; }
+
+    [JsonPropertyName("identifierNetworkOperator")]
+    public long MarketPartnerId { get; set; }
+
+    [JsonConverter(typeof(DateTimeOffsetWithTrailingZConverter))]
+    [JsonPropertyName("executionTimeFrom")]
+    public DateTimeOffset ExecutionTimeFrom { get; set; }
+
+    [JsonConverter(typeof(NullableDateTimeOffsetWithTrailingZConverter))]
+    [JsonPropertyName("executionTimeUntil")]
+    public DateTimeOffset? ExecutionTimeUntil { get; set; }
+}

--- a/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationNetworkOperator.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationNetworkOperator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 using MaLoIdentModels.JsonSettings;
 
@@ -8,15 +9,16 @@ namespace MaLoIdentModels.v2;
 public class MarketLocationNetworkOperator
 {
     [JsonIgnore]
-    [System.ComponentModel.DataAnnotations.Key]
+    [Key]
     public Guid? Id { get; set; }
 
     /// <summary>
-    /// The 13-digit market partner ID. Serialized as <c>identifierNetworkOperator</c> on the wire.
-    /// The spec uses <c>string</c> with pattern <c>^\d{13}$</c>, but we keep <c>long</c> for type safety.
+    /// 13-digit market partner ID as string per v2 spec.
+    /// Serialized as <c>identifierNetworkOperator</c> on the wire.
     /// </summary>
     [JsonPropertyName("identifierNetworkOperator")]
-    public long MarketPartnerId { get; set; }
+    [RegularExpression(@"^\d{13}$")]
+    public string? MarketPartnerId { get; set; }
 
     [JsonConverter(typeof(DateTimeOffsetWithTrailingZConverter))]
     [JsonPropertyName("executionTimeFrom")]

--- a/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationNetworkOperator.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationNetworkOperator.cs
@@ -4,6 +4,7 @@ using MaLoIdentModels.JsonSettings;
 
 namespace MaLoIdentModels.v2;
 
+/// <seealso cref="v1.MarketLocationNetworkOperator">v1 equivalent</seealso>
 public class MarketLocationNetworkOperator
 {
     [JsonIgnore]

--- a/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationNetworkOperator.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationNetworkOperator.cs
@@ -10,6 +10,10 @@ public class MarketLocationNetworkOperator
     [System.ComponentModel.DataAnnotations.Key]
     public Guid? Id { get; set; }
 
+    /// <summary>
+    /// The 13-digit market partner ID. Serialized as <c>identifierNetworkOperator</c> on the wire.
+    /// The spec uses <c>string</c> with pattern <c>^\d{13}$</c>, but we keep <c>long</c> for type safety.
+    /// </summary>
     [JsonPropertyName("identifierNetworkOperator")]
     public long MarketPartnerId { get; set; }
 

--- a/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationProperty.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationProperty.cs
@@ -1,0 +1,19 @@
+using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+
+namespace MaLoIdentModels.v2;
+
+public enum MarketLocationProperty
+{
+    [EnumMember(Value = "customerFacility")]
+    [JsonStringEnumMemberName("customerFacility")]
+    CustomerFacility,
+
+    [EnumMember(Value = "nonActive")]
+    [JsonStringEnumMemberName("nonActive")]
+    NonActive,
+
+    [EnumMember(Value = "standard")]
+    [JsonStringEnumMemberName("standard")]
+    Standard,
+}

--- a/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationSupplier.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationSupplier.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 using MaLoIdentModels.JsonSettings;
 
@@ -8,15 +9,16 @@ namespace MaLoIdentModels.v2;
 public class MarketLocationSupplier
 {
     [JsonIgnore]
-    [System.ComponentModel.DataAnnotations.Key]
+    [Key]
     public Guid? Id { get; set; }
 
     /// <summary>
-    /// The 13-digit market partner ID. Serialized as <c>identifierSupplier</c> on the wire.
-    /// The spec uses <c>string</c> with pattern <c>^\d{13}$</c>, but we keep <c>long</c> for type safety.
+    /// 13-digit market partner ID as string per v2 spec.
+    /// Serialized as <c>identifierSupplier</c> on the wire.
     /// </summary>
     [JsonPropertyName("identifierSupplier")]
-    public long MarketPartnerId { get; set; }
+    [RegularExpression(@"^\d{13}$")]
+    public string? MarketPartnerId { get; set; }
 
     [JsonConverter(typeof(DateTimeOffsetWithTrailingZConverter))]
     [JsonPropertyName("executionTimeFrom")]

--- a/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationSupplier.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationSupplier.cs
@@ -10,6 +10,10 @@ public class MarketLocationSupplier
     [System.ComponentModel.DataAnnotations.Key]
     public Guid? Id { get; set; }
 
+    /// <summary>
+    /// The 13-digit market partner ID. Serialized as <c>identifierSupplier</c> on the wire.
+    /// The spec uses <c>string</c> with pattern <c>^\d{13}$</c>, but we keep <c>long</c> for type safety.
+    /// </summary>
     [JsonPropertyName("identifierSupplier")]
     public long MarketPartnerId { get; set; }
 

--- a/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationSupplier.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationSupplier.cs
@@ -4,6 +4,7 @@ using MaLoIdentModels.JsonSettings;
 
 namespace MaLoIdentModels.v2;
 
+/// <seealso cref="v1.MarketLocationSupplier">v1 equivalent</seealso>
 public class MarketLocationSupplier
 {
     [JsonIgnore]

--- a/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationSupplier.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationSupplier.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Text.Json.Serialization;
+using MaLoIdentModels.JsonSettings;
+
+namespace MaLoIdentModels.v2;
+
+public class MarketLocationSupplier
+{
+    [JsonIgnore]
+    [System.ComponentModel.DataAnnotations.Key]
+    public Guid? Id { get; set; }
+
+    [JsonPropertyName("identifierSupplier")]
+    public long MarketPartnerId { get; set; }
+
+    [JsonConverter(typeof(DateTimeOffsetWithTrailingZConverter))]
+    [JsonPropertyName("executionTimeFrom")]
+    public DateTimeOffset ExecutionTimeFrom { get; set; }
+
+    [JsonConverter(typeof(NullableDateTimeOffsetWithTrailingZConverter))]
+    [JsonPropertyName("executionTimeUntil")]
+    public DateTimeOffset? ExecutionTimeUntil { get; set; }
+}

--- a/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationTransmissionSystemOperator.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationTransmissionSystemOperator.cs
@@ -4,6 +4,7 @@ using MaLoIdentModels.JsonSettings;
 
 namespace MaLoIdentModels.v2;
 
+/// <seealso cref="v1.MarketLocationTransmissionSystemOperator">v1 equivalent</seealso>
 public class MarketLocationTransmissionSystemOperator
 {
     [JsonIgnore]

--- a/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationTransmissionSystemOperator.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationTransmissionSystemOperator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 using MaLoIdentModels.JsonSettings;
 
@@ -8,15 +9,16 @@ namespace MaLoIdentModels.v2;
 public class MarketLocationTransmissionSystemOperator
 {
     [JsonIgnore]
-    [System.ComponentModel.DataAnnotations.Key]
+    [Key]
     public Guid? Id { get; set; }
 
     /// <summary>
-    /// The 13-digit market partner ID. Serialized as <c>identifierTransmissionSystemOperator</c> on the wire.
-    /// The spec uses <c>string</c> with pattern <c>^\d{13}$</c>, but we keep <c>long</c> for type safety.
+    /// 13-digit market partner ID as string per v2 spec.
+    /// Serialized as <c>identifierTransmissionSystemOperator</c> on the wire.
     /// </summary>
     [JsonPropertyName("identifierTransmissionSystemOperator")]
-    public long MarketPartnerId { get; set; }
+    [RegularExpression(@"^\d{13}$")]
+    public string? MarketPartnerId { get; set; }
 
     [JsonConverter(typeof(DateTimeOffsetWithTrailingZConverter))]
     [JsonPropertyName("executionTimeFrom")]

--- a/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationTransmissionSystemOperator.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationTransmissionSystemOperator.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Text.Json.Serialization;
+using MaLoIdentModels.JsonSettings;
+
+namespace MaLoIdentModels.v2;
+
+public class MarketLocationTransmissionSystemOperator
+{
+    [JsonIgnore]
+    [System.ComponentModel.DataAnnotations.Key]
+    public Guid? Id { get; set; }
+
+    [JsonPropertyName("identifierTransmissionSystemOperator")]
+    public long MarketPartnerId { get; set; }
+
+    [JsonConverter(typeof(DateTimeOffsetWithTrailingZConverter))]
+    [JsonPropertyName("executionTimeFrom")]
+    public DateTimeOffset ExecutionTimeFrom { get; set; }
+
+    [JsonConverter(typeof(NullableDateTimeOffsetWithTrailingZConverter))]
+    [JsonPropertyName("executionTimeUntil")]
+    public DateTimeOffset? ExecutionTimeUntil { get; set; }
+}

--- a/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationTransmissionSystemOperator.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/MarketLocationTransmissionSystemOperator.cs
@@ -10,6 +10,10 @@ public class MarketLocationTransmissionSystemOperator
     [System.ComponentModel.DataAnnotations.Key]
     public Guid? Id { get; set; }
 
+    /// <summary>
+    /// The 13-digit market partner ID. Serialized as <c>identifierTransmissionSystemOperator</c> on the wire.
+    /// The spec uses <c>string</c> with pattern <c>^\d{13}$</c>, but we keep <c>long</c> for type safety.
+    /// </summary>
     [JsonPropertyName("identifierTransmissionSystemOperator")]
     public long MarketPartnerId { get; set; }
 

--- a/MaLoIdentModels/MaLoIdentModels/v2/MeasurementTechnologyClassification.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/MeasurementTechnologyClassification.cs
@@ -1,0 +1,19 @@
+using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+
+namespace MaLoIdentModels.v2;
+
+public enum MeasurementTechnologyClassification
+{
+    [EnumMember(Value = "intelligentMeasuringSystem")]
+    [JsonStringEnumMemberName("intelligentMeasuringSystem")]
+    IntelligentMeasuringSystem,
+
+    [EnumMember(Value = "conventionalMeasuringSystem")]
+    [JsonStringEnumMemberName("conventionalMeasuringSystem")]
+    ConventionalMeasuringSystem,
+
+    [EnumMember(Value = "noMeasurement")]
+    [JsonStringEnumMemberName("noMeasurement")]
+    NoMeasurement,
+}

--- a/MaLoIdentModels/MaLoIdentModels/v2/MeterLocation.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/MeterLocation.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace MaLoIdentModels.v2;
+
+public class MeterLocation
+{
+    [JsonIgnore]
+    [System.ComponentModel.DataAnnotations.Key]
+    public System.Guid? Id { get; set; }
+
+    [JsonPropertyName("identifierMeterLocation")]
+    public string? IdentifierMeterLocation { get; set; }
+
+    [JsonPropertyName("meterNumber")]
+    public string? MeterNumber { get; set; }
+
+    [JsonPropertyName("meterLocationMeasuringPointOperators")]
+    public List<MeterLocationMeasuringPointOperator>? MeterLocationMeasuringPointOperators { get; set; }
+}

--- a/MaLoIdentModels/MaLoIdentModels/v2/MeterLocation.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/MeterLocation.cs
@@ -3,12 +3,16 @@ using System.Text.Json.Serialization;
 
 namespace MaLoIdentModels.v2;
 
+/// <seealso cref="v1.DataMeterLocation">v1 equivalent (DataMeterLocation)</seealso>
 public class MeterLocation
 {
     [JsonIgnore]
     [System.ComponentModel.DataAnnotations.Key]
     public System.Guid? Id { get; set; }
 
+    /// <summary>
+    /// The meter location identifier. Was <see cref="v1.DataMeterLocation.MeloId"/> in v1.
+    /// </summary>
     [JsonPropertyName("identifierMeterLocation")]
     public string? IdentifierMeterLocation { get; set; }
 

--- a/MaLoIdentModels/MaLoIdentModels/v2/MeterLocationMeasuringPointOperator.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/MeterLocationMeasuringPointOperator.cs
@@ -4,6 +4,7 @@ using MaLoIdentModels.JsonSettings;
 
 namespace MaLoIdentModels.v2;
 
+/// <seealso cref="v1.MeterLocationMeasuringPointOperator">v1 equivalent</seealso>
 public class MeterLocationMeasuringPointOperator
 {
     [JsonIgnore]

--- a/MaLoIdentModels/MaLoIdentModels/v2/MeterLocationMeasuringPointOperator.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/MeterLocationMeasuringPointOperator.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Text.Json.Serialization;
+using MaLoIdentModels.JsonSettings;
+
+namespace MaLoIdentModels.v2;
+
+public class MeterLocationMeasuringPointOperator
+{
+    [JsonIgnore]
+    [System.ComponentModel.DataAnnotations.Key]
+    public Guid? Id { get; set; }
+
+    [JsonPropertyName("identifierMeasuringPointOperator")]
+    public long MarketPartnerId { get; set; }
+
+    [JsonConverter(typeof(DateTimeOffsetWithTrailingZConverter))]
+    [JsonPropertyName("executionTimeFrom")]
+    public DateTimeOffset ExecutionTimeFrom { get; set; }
+
+    [JsonConverter(typeof(NullableDateTimeOffsetWithTrailingZConverter))]
+    [JsonPropertyName("executionTimeUntil")]
+    public DateTimeOffset? ExecutionTimeUntil { get; set; }
+}

--- a/MaLoIdentModels/MaLoIdentModels/v2/MeterLocationMeasuringPointOperator.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/MeterLocationMeasuringPointOperator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 using MaLoIdentModels.JsonSettings;
 
@@ -8,15 +9,16 @@ namespace MaLoIdentModels.v2;
 public class MeterLocationMeasuringPointOperator
 {
     [JsonIgnore]
-    [System.ComponentModel.DataAnnotations.Key]
+    [Key]
     public Guid? Id { get; set; }
 
     /// <summary>
-    /// The 13-digit market partner ID. Serialized as <c>identifierMeasuringPointOperator</c> on the wire.
-    /// The spec uses <c>string</c> with pattern <c>^\d{13}$</c>, but we keep <c>long</c> for type safety.
+    /// 13-digit market partner ID as string per v2 spec.
+    /// Serialized as <c>identifierMeasuringPointOperator</c> on the wire.
     /// </summary>
     [JsonPropertyName("identifierMeasuringPointOperator")]
-    public long MarketPartnerId { get; set; }
+    [RegularExpression(@"^\d{13}$")]
+    public string? MarketPartnerId { get; set; }
 
     [JsonConverter(typeof(DateTimeOffsetWithTrailingZConverter))]
     [JsonPropertyName("executionTimeFrom")]

--- a/MaLoIdentModels/MaLoIdentModels/v2/MeterLocationMeasuringPointOperator.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/MeterLocationMeasuringPointOperator.cs
@@ -10,6 +10,10 @@ public class MeterLocationMeasuringPointOperator
     [System.ComponentModel.DataAnnotations.Key]
     public Guid? Id { get; set; }
 
+    /// <summary>
+    /// The 13-digit market partner ID. Serialized as <c>identifierMeasuringPointOperator</c> on the wire.
+    /// The spec uses <c>string</c> with pattern <c>^\d{13}$</c>, but we keep <c>long</c> for type safety.
+    /// </summary>
     [JsonPropertyName("identifierMeasuringPointOperator")]
     public long MarketPartnerId { get; set; }
 

--- a/MaLoIdentModels/MaLoIdentModels/v2/Name.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/Name.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+using MaLoIdentModels.JsonSettings;
+
+namespace MaLoIdentModels.v2;
+
+public class Name
+{
+    [JsonIgnore]
+    [System.ComponentModel.DataAnnotations.Key]
+    public System.Guid? Id { get; set; }
+
+    [JsonConverter(typeof(EmptyStringConverter))]
+    [JsonPropertyName("surnames")]
+    public string? Surnames { get; set; }
+
+    [JsonConverter(typeof(EmptyStringConverter))]
+    [JsonPropertyName("firstnames")]
+    public string? Firstnames { get; set; }
+
+    [JsonConverter(typeof(EmptyStringConverter))]
+    [JsonPropertyName("title")]
+    public string? Title { get; set; }
+
+    [JsonConverter(typeof(EmptyStringConverter))]
+    [JsonPropertyName("company")]
+    public string? Company { get; set; }
+}

--- a/MaLoIdentModels/MaLoIdentModels/v2/NetworkLocation.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/NetworkLocation.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace MaLoIdentModels.v2;
+
+public class NetworkLocation
+{
+    [JsonIgnore]
+    [System.ComponentModel.DataAnnotations.Key]
+    public System.Guid? Id { get; set; }
+
+    [JsonPropertyName("identifierNetworkLocation")]
+    public string? IdentifierNetworkLocation { get; set; }
+
+    [JsonPropertyName("networkLocationMeasuringPointOperators")]
+    public List<NetworkLocationMeasuringPointOperator>? NetworkLocationMeasuringPointOperators { get; set; }
+}

--- a/MaLoIdentModels/MaLoIdentModels/v2/NetworkLocation.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/NetworkLocation.cs
@@ -3,12 +3,16 @@ using System.Text.Json.Serialization;
 
 namespace MaLoIdentModels.v2;
 
+/// <seealso cref="v1.DataNetworkLocation">v1 equivalent (DataNetworkLocation)</seealso>
 public class NetworkLocation
 {
     [JsonIgnore]
     [System.ComponentModel.DataAnnotations.Key]
     public System.Guid? Id { get; set; }
 
+    /// <summary>
+    /// The network location identifier. Was <see cref="v1.DataNetworkLocation.NeloId"/> in v1.
+    /// </summary>
     [JsonPropertyName("identifierNetworkLocation")]
     public string? IdentifierNetworkLocation { get; set; }
 

--- a/MaLoIdentModels/MaLoIdentModels/v2/NetworkLocationMeasuringPointOperator.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/NetworkLocationMeasuringPointOperator.cs
@@ -4,6 +4,7 @@ using MaLoIdentModels.JsonSettings;
 
 namespace MaLoIdentModels.v2;
 
+/// <seealso cref="v1.NetworkLocationMeasuringPointOperator">v1 equivalent</seealso>
 public class NetworkLocationMeasuringPointOperator
 {
     [JsonIgnore]

--- a/MaLoIdentModels/MaLoIdentModels/v2/NetworkLocationMeasuringPointOperator.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/NetworkLocationMeasuringPointOperator.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Text.Json.Serialization;
+using MaLoIdentModels.JsonSettings;
+
+namespace MaLoIdentModels.v2;
+
+public class NetworkLocationMeasuringPointOperator
+{
+    [JsonIgnore]
+    [System.ComponentModel.DataAnnotations.Key]
+    public Guid? Id { get; set; }
+
+    [JsonPropertyName("identifierMeasuringPointOperator")]
+    public long MarketPartnerId { get; set; }
+
+    [JsonConverter(typeof(DateTimeOffsetWithTrailingZConverter))]
+    [JsonPropertyName("executionTimeFrom")]
+    public DateTimeOffset ExecutionTimeFrom { get; set; }
+
+    [JsonConverter(typeof(NullableDateTimeOffsetWithTrailingZConverter))]
+    [JsonPropertyName("executionTimeUntil")]
+    public DateTimeOffset? ExecutionTimeUntil { get; set; }
+}

--- a/MaLoIdentModels/MaLoIdentModels/v2/NetworkLocationMeasuringPointOperator.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/NetworkLocationMeasuringPointOperator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 using MaLoIdentModels.JsonSettings;
 
@@ -8,15 +9,16 @@ namespace MaLoIdentModels.v2;
 public class NetworkLocationMeasuringPointOperator
 {
     [JsonIgnore]
-    [System.ComponentModel.DataAnnotations.Key]
+    [Key]
     public Guid? Id { get; set; }
 
     /// <summary>
-    /// The 13-digit market partner ID. Serialized as <c>identifierMeasuringPointOperator</c> on the wire.
-    /// The spec uses <c>string</c> with pattern <c>^\d{13}$</c>, but we keep <c>long</c> for type safety.
+    /// 13-digit market partner ID as string per v2 spec.
+    /// Serialized as <c>identifierMeasuringPointOperator</c> on the wire.
     /// </summary>
     [JsonPropertyName("identifierMeasuringPointOperator")]
-    public long MarketPartnerId { get; set; }
+    [RegularExpression(@"^\d{13}$")]
+    public string? MarketPartnerId { get; set; }
 
     [JsonConverter(typeof(DateTimeOffsetWithTrailingZConverter))]
     [JsonPropertyName("executionTimeFrom")]

--- a/MaLoIdentModels/MaLoIdentModels/v2/NetworkLocationMeasuringPointOperator.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/NetworkLocationMeasuringPointOperator.cs
@@ -10,6 +10,10 @@ public class NetworkLocationMeasuringPointOperator
     [System.ComponentModel.DataAnnotations.Key]
     public Guid? Id { get; set; }
 
+    /// <summary>
+    /// The 13-digit market partner ID. Serialized as <c>identifierMeasuringPointOperator</c> on the wire.
+    /// The spec uses <c>string</c> with pattern <c>^\d{13}$</c>, but we keep <c>long</c> for type safety.
+    /// </summary>
     [JsonPropertyName("identifierMeasuringPointOperator")]
     public long MarketPartnerId { get; set; }
 

--- a/MaLoIdentModels/MaLoIdentModels/v2/Proportion.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/Proportion.cs
@@ -1,0 +1,15 @@
+using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+
+namespace MaLoIdentModels.v2;
+
+public enum Proportion
+{
+    [EnumMember(Value = "bilateralAgreement")]
+    [JsonStringEnumMemberName("bilateralAgreement")]
+    BilateralAgreement,
+
+    [EnumMember(Value = "percent")]
+    [JsonStringEnumMemberName("percent")]
+    Percent,
+}

--- a/MaLoIdentModels/MaLoIdentModels/v2/README.md
+++ b/MaLoIdentModels/MaLoIdentModels/v2/README.md
@@ -1,4 +1,5 @@
 # FV2510
+
 Contains the data model as of October 2026.
 EDI@Energy names this "v2.0.0".
 

--- a/MaLoIdentModels/MaLoIdentModels/v2/README.md
+++ b/MaLoIdentModels/MaLoIdentModels/v2/README.md
@@ -1,0 +1,5 @@
+# FV2510
+Contains the data model as of October 2026.
+EDI@Energy names this "v2.0.0".
+
+Based on [EDI-Energy/api-electricity](https://github.com/EDI-Energy/api-electricity) tag [`2.0.0`](https://github.com/EDI-Energy/api-electricity/releases/tag/2.0.0) (commit [`0a5a9f2`](https://github.com/EDI-Energy/api-electricity/commit/0a5a9f2e6fb72c1c34583a2bcedb7a48bd4499ba), 2026-01-28).

--- a/MaLoIdentModels/MaLoIdentModels/v2/ResultNegative.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/ResultNegative.cs
@@ -3,6 +3,7 @@ using System.Text.Json.Serialization;
 
 namespace MaLoIdentModels.v2;
 
+/// <seealso cref="v1.ResultNegative">v1 equivalent</seealso>
 public class ResultNegative
 {
     [JsonIgnore]
@@ -20,6 +21,9 @@ public class ResultNegative
     [JsonPropertyName("reason")]
     public string? Reason { get; set; }
 
+    /// <summary>
+    /// The network operator's market partner ID. Was <see cref="v1.ResultNegative.NetworkOperator"/> in v1.
+    /// </summary>
     [JsonPropertyName("identifierNetworkOperator")]
     public long? IdentifierNetworkOperator { get; set; }
 }

--- a/MaLoIdentModels/MaLoIdentModels/v2/ResultNegative.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/ResultNegative.cs
@@ -11,11 +11,11 @@ public class ResultNegative
     public System.Guid? Id { get; set; }
 
     [JsonPropertyName("decisionTree")]
-    [RegularExpression(@"E_\d{4}")]
+    [RegularExpression(@"^E_\d{4}$")] // anchors added; spec pattern is unanchored: https://github.com/EDI-Energy/api-electricity/issues/46
     public string? DecisionTree { get; set; }
 
     [JsonPropertyName("responseCode")]
-    [RegularExpression(@"A[A-Z\d]{2}")]
+    [RegularExpression(@"^A[A-Z\d]{2}$")] // anchors added; spec pattern is unanchored: https://github.com/EDI-Energy/api-electricity/issues/46
     public string? ResponseCode { get; set; }
 
     [JsonPropertyName("reason")]

--- a/MaLoIdentModels/MaLoIdentModels/v2/ResultNegative.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/ResultNegative.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace MaLoIdentModels.v2;
+
+public class ResultNegative
+{
+    [JsonIgnore]
+    [Key]
+    public System.Guid? Id { get; set; }
+
+    [JsonPropertyName("decisionTree")]
+    [RegularExpression(@"E_\d{4}")]
+    public string? DecisionTree { get; set; }
+
+    [JsonPropertyName("responseCode")]
+    [RegularExpression(@"A[A-Z\d]{2}")]
+    public string? ResponseCode { get; set; }
+
+    [JsonPropertyName("reason")]
+    public string? Reason { get; set; }
+
+    [JsonPropertyName("identifierNetworkOperator")]
+    public long? IdentifierNetworkOperator { get; set; }
+}

--- a/MaLoIdentModels/MaLoIdentModels/v2/ResultNegative.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/ResultNegative.cs
@@ -22,8 +22,11 @@ public class ResultNegative
     public string? Reason { get; set; }
 
     /// <summary>
-    /// The network operator's market partner ID. Was <see cref="v1.ResultNegative.NetworkOperator"/> in v1.
+    /// The network operator's 13-digit market partner ID as string per v2 spec.
+    /// Serialized as <c>identifierNetworkOperator</c> on the wire.
+    /// Was <see cref="v1.ResultNegative.NetworkOperator"/> in v1.
     /// </summary>
     [JsonPropertyName("identifierNetworkOperator")]
-    public long? IdentifierNetworkOperator { get; set; }
+    [RegularExpression(@"^\d{13}$")]
+    public string? IdentifierNetworkOperator { get; set; }
 }

--- a/MaLoIdentModels/MaLoIdentModels/v2/ResultPositive.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/ResultPositive.cs
@@ -5,6 +5,7 @@ using MaLoIdentModels.JsonSettings;
 
 namespace MaLoIdentModels.v2;
 
+/// <seealso cref="v1.ResultPositive">v1 equivalent</seealso>
 public class ResultPositive
 {
     [JsonIgnore]

--- a/MaLoIdentModels/MaLoIdentModels/v2/ResultPositive.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/ResultPositive.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+using MaLoIdentModels.JsonSettings;
+
+namespace MaLoIdentModels.v2;
+
+public class ResultPositive
+{
+    [JsonIgnore]
+    [Key]
+    public System.Guid? Id { get; set; }
+
+    [JsonPropertyName("marketLocation")]
+    public MarketLocation? MarketLocation { get; set; }
+
+    [JsonConverter(typeof(EmptyListToNullConverter<Tranche>))]
+    [JsonPropertyName("tranches")]
+    public List<Tranche>? Tranches { get; set; }
+
+    [JsonConverter(typeof(EmptyListToNullConverter<MeterLocation>))]
+    [JsonPropertyName("meterLocations")]
+    public List<MeterLocation>? MeterLocations { get; set; }
+
+    [JsonConverter(typeof(EmptyListToNullConverter<TechnicalResource>))]
+    [JsonPropertyName("technicalResources")]
+    public List<TechnicalResource>? TechnicalResources { get; set; }
+
+    [JsonConverter(typeof(EmptyListToNullConverter<ControllableResource>))]
+    [JsonPropertyName("controllableResources")]
+    public List<ControllableResource>? ControllableResources { get; set; }
+
+    [JsonConverter(typeof(EmptyListToNullConverter<NetworkLocation>))]
+    [JsonPropertyName("networkLocations")]
+    public List<NetworkLocation>? NetworkLocations { get; set; }
+}

--- a/MaLoIdentModels/MaLoIdentModels/v2/TechnicalResource.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/TechnicalResource.cs
@@ -2,12 +2,16 @@ using System.Text.Json.Serialization;
 
 namespace MaLoIdentModels.v2;
 
+/// <seealso cref="v1.DataTechnicalResource">v1 equivalent (DataTechnicalResource)</seealso>
 public class TechnicalResource
 {
     [JsonIgnore]
     [System.ComponentModel.DataAnnotations.Key]
     public System.Guid? Id { get; set; }
 
+    /// <summary>
+    /// The technical resource identifier. Was <see cref="v1.DataTechnicalResource.TrId"/> in v1.
+    /// </summary>
     [JsonPropertyName("identifierTechnicalResource")]
     public string? IdentifierTechnicalResource { get; set; }
 }

--- a/MaLoIdentModels/MaLoIdentModels/v2/TechnicalResource.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/TechnicalResource.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+
+namespace MaLoIdentModels.v2;
+
+public class TechnicalResource
+{
+    [JsonIgnore]
+    [System.ComponentModel.DataAnnotations.Key]
+    public System.Guid? Id { get; set; }
+
+    [JsonPropertyName("identifierTechnicalResource")]
+    public string? IdentifierTechnicalResource { get; set; }
+}

--- a/MaLoIdentModels/MaLoIdentModels/v2/Tranche.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/Tranche.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using MaLoIdentModels.JsonSettings;
+using MaLoIdentModels.Validation;
+
+namespace MaLoIdentModels.v2;
+
+public class Tranche
+{
+    [JsonIgnore]
+    [System.ComponentModel.DataAnnotations.Key]
+    public System.Guid? Id { get; set; }
+
+    [JsonPropertyName("identifierTranche")]
+    public string? IdentifierTranche { get; set; }
+
+    [JsonPropertyName("proportion")]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public Proportion Proportion { get; set; }
+
+    [PercentLessHundredValidation]
+    [JsonConverter(typeof(PercentLessHundredConverter))]
+    [JsonPropertyName("percentLessHundred")]
+    public decimal? PercentLessHundred { get; set; }
+
+    [JsonPropertyName("trancheSuppliers")]
+    public List<TrancheSupplier>? TrancheSuppliers { get; set; }
+}

--- a/MaLoIdentModels/MaLoIdentModels/v2/Tranche.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/Tranche.cs
@@ -5,12 +5,16 @@ using MaLoIdentModels.Validation;
 
 namespace MaLoIdentModels.v2;
 
+/// <seealso cref="v1.DataTranche">v1 equivalent (DataTranche)</seealso>
 public class Tranche
 {
     [JsonIgnore]
     [System.ComponentModel.DataAnnotations.Key]
     public System.Guid? Id { get; set; }
 
+    /// <summary>
+    /// The tranche identifier. Was <see cref="v1.DataTranche.TranchenId"/> in v1.
+    /// </summary>
     [JsonPropertyName("identifierTranche")]
     public string? IdentifierTranche { get; set; }
 
@@ -18,6 +22,10 @@ public class Tranche
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public Proportion Proportion { get; set; }
 
+    /// <summary>
+    /// The tranche percentage. Was <see cref="v1.DataTranche.Percent"/> in v1.
+    /// v2 uses a string wire format; the <see cref="PercentLessHundredConverter"/> handles conversion transparently.
+    /// </summary>
     [PercentLessHundredValidation]
     [JsonConverter(typeof(PercentLessHundredConverter))]
     [JsonPropertyName("percentLessHundred")]

--- a/MaLoIdentModels/MaLoIdentModels/v2/TrancheSupplier.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/TrancheSupplier.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Text.Json.Serialization;
+using MaLoIdentModels.JsonSettings;
+
+namespace MaLoIdentModels.v2;
+
+public class TrancheSupplier
+{
+    [JsonIgnore]
+    [System.ComponentModel.DataAnnotations.Key]
+    public Guid? Id { get; set; }
+
+    [JsonPropertyName("identifierSupplier")]
+    public long MarketPartnerId { get; set; }
+
+    [JsonConverter(typeof(DateTimeOffsetWithTrailingZConverter))]
+    [JsonPropertyName("executionTimeFrom")]
+    public DateTimeOffset ExecutionTimeFrom { get; set; }
+
+    [JsonConverter(typeof(NullableDateTimeOffsetWithTrailingZConverter))]
+    [JsonPropertyName("executionTimeUntil")]
+    public DateTimeOffset? ExecutionTimeUntil { get; set; }
+}

--- a/MaLoIdentModels/MaLoIdentModels/v2/TrancheSupplier.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/TrancheSupplier.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 using MaLoIdentModels.JsonSettings;
 
@@ -8,15 +9,16 @@ namespace MaLoIdentModels.v2;
 public class TrancheSupplier
 {
     [JsonIgnore]
-    [System.ComponentModel.DataAnnotations.Key]
+    [Key]
     public Guid? Id { get; set; }
 
     /// <summary>
-    /// The 13-digit market partner ID. Serialized as <c>identifierSupplier</c> on the wire.
-    /// The spec uses <c>string</c> with pattern <c>^\d{13}$</c>, but we keep <c>long</c> for type safety.
+    /// 13-digit market partner ID as string per v2 spec.
+    /// Serialized as <c>identifierSupplier</c> on the wire.
     /// </summary>
     [JsonPropertyName("identifierSupplier")]
-    public long MarketPartnerId { get; set; }
+    [RegularExpression(@"^\d{13}$")]
+    public string? MarketPartnerId { get; set; }
 
     [JsonConverter(typeof(DateTimeOffsetWithTrailingZConverter))]
     [JsonPropertyName("executionTimeFrom")]

--- a/MaLoIdentModels/MaLoIdentModels/v2/TrancheSupplier.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/TrancheSupplier.cs
@@ -4,6 +4,7 @@ using MaLoIdentModels.JsonSettings;
 
 namespace MaLoIdentModels.v2;
 
+/// <seealso cref="v1.TrancheSupplier">v1 equivalent</seealso>
 public class TrancheSupplier
 {
     [JsonIgnore]

--- a/MaLoIdentModels/MaLoIdentModels/v2/TrancheSupplier.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/TrancheSupplier.cs
@@ -10,6 +10,10 @@ public class TrancheSupplier
     [System.ComponentModel.DataAnnotations.Key]
     public Guid? Id { get; set; }
 
+    /// <summary>
+    /// The 13-digit market partner ID. Serialized as <c>identifierSupplier</c> on the wire.
+    /// The spec uses <c>string</c> with pattern <c>^\d{13}$</c>, but we keep <c>long</c> for type safety.
+    /// </summary>
     [JsonPropertyName("identifierSupplier")]
     public long MarketPartnerId { get; set; }
 

--- a/MaLoIdentModels/MaLoIdentModels/v2/Zone.cs
+++ b/MaLoIdentModels/MaLoIdentModels/v2/Zone.cs
@@ -1,0 +1,19 @@
+using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+
+namespace MaLoIdentModels.v2;
+
+public enum Zone
+{
+    [EnumMember(Value = "UTMZone31")]
+    [JsonStringEnumMemberName("UTMZone31")]
+    UTMZone31,
+
+    [EnumMember(Value = "UTMZone32")]
+    [JsonStringEnumMemberName("UTMZone32")]
+    UTMZone32,
+
+    [EnumMember(Value = "UTMZone33")]
+    [JsonStringEnumMemberName("UTMZone33")]
+    UTMZone33,
+}

--- a/MaLoIdentModels/MaLoIdentModelsTests/MaLoIdentModelsTests.csproj
+++ b/MaLoIdentModels/MaLoIdentModelsTests/MaLoIdentModelsTests.csproj
@@ -35,6 +35,21 @@
     <None Update="v1Tests\examples\positive_response_empty_lists.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="v2Tests\examples\request.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="v2Tests\examples\result_negative.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="v2Tests\examples\result_positive.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="v2Tests\examples\request_empty_string.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="v2Tests\examples\result_positive_empty_lists.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MaLoIdentModels\MaLoIdentModels.csproj" />

--- a/MaLoIdentModels/MaLoIdentModelsTests/MaLoIdentModelsTests.csproj
+++ b/MaLoIdentModels/MaLoIdentModelsTests/MaLoIdentModelsTests.csproj
@@ -48,6 +48,8 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="v2Tests\examples\result_positive_empty_lists.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="v1Tests\examples\dataForMarketLocationPositive_real_world.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/MaLoIdentModels/MaLoIdentModelsTests/v1Tests/RoundTripTests.cs
+++ b/MaLoIdentModels/MaLoIdentModelsTests/v1Tests/RoundTripTests.cs
@@ -79,9 +79,7 @@ public class RoundTripTests
             .DataMarketLocation.DataMarketLocationSuppliers.Should()
             .NotBeNullOrEmpty()
             .And.HaveCount(1);
-        model
-            .DataMarketLocation.DataMarketLocationAddress.Should()
-            .NotBeNull();
+        model.DataMarketLocation.DataMarketLocationAddress.Should().NotBeNull();
         model.DataMarketLocation.DataMarketLocationAddress!.City.Should().Be("Nürnberg");
         model.DataMeterLocations.Should().NotBeNullOrEmpty().And.HaveCount(1);
         model.DataMeterLocations![0].MeloId.Should().Be("DE0001111222222223333333333344444");

--- a/MaLoIdentModels/MaLoIdentModelsTests/v2Tests/AdditionalDeserializationTests.cs
+++ b/MaLoIdentModels/MaLoIdentModelsTests/v2Tests/AdditionalDeserializationTests.cs
@@ -64,7 +64,7 @@ public class AdditionalDeserializationTests
     {
         var json = """
             {
-                "identifierNetworkOperator": 9900987654321,
+                "identifierNetworkOperator": "9900987654321",
                 "executionTimeFrom": "2023-08-01T22:00:00Z",
                 "executionTimeUntil": null
             }
@@ -82,7 +82,7 @@ public class AdditionalDeserializationTests
     {
         var json = """
             {
-                "identifierNetworkOperator": 9900987654321,
+                "identifierNetworkOperator": "9900987654321",
                 "executionTimeFrom": "2023-08-01T22:00:00Z"
             }
             """;

--- a/MaLoIdentModels/MaLoIdentModelsTests/v2Tests/AdditionalDeserializationTests.cs
+++ b/MaLoIdentModels/MaLoIdentModelsTests/v2Tests/AdditionalDeserializationTests.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Text.Json;
+using AwesomeAssertions;
+using MaLoIdentModels.v2;
+
+namespace MaLoIdentModelsTests.v2Tests;
+
+public class AdditionalDeserializationTests
+{
+    [Fact]
+    public void Zone_Null_Deserializes_To_Null()
+    {
+        var json = """
+            {
+                "latitude": "52.52",
+                "longitude": "13.405",
+                "zone": null
+            }
+            """;
+        var model = JsonSerializer.Deserialize<GeographicCoordinates>(json);
+        model.Should().NotBeNull();
+        model!.Zone.Should().BeNull();
+    }
+
+    [Fact]
+    public void Zone_Missing_Deserializes_To_Null()
+    {
+        var json = """
+            {
+                "latitude": "52.52",
+                "longitude": "13.405"
+            }
+            """;
+        var model = JsonSerializer.Deserialize<GeographicCoordinates>(json);
+        model.Should().NotBeNull();
+        model!.Zone.Should().BeNull();
+    }
+
+    [Fact]
+    public void Zone_Valid_Value_Deserializes()
+    {
+        var json = """
+            {
+                "latitude": "52.52",
+                "longitude": "13.405",
+                "zone": "UTMZone32"
+            }
+            """;
+        var model = JsonSerializer.Deserialize<GeographicCoordinates>(json);
+        model.Should().NotBeNull();
+        model!.Zone.Should().Be(Zone.UTMZone32);
+    }
+
+    [Fact]
+    public void Zone_Null_Serializes_To_Null()
+    {
+        var model = new GeographicCoordinates { Zone = null };
+        var json = JsonSerializer.Serialize(model);
+        json.Should().Contain("\"zone\":null");
+    }
+
+    [Fact]
+    public void Null_ExecutionTimeUntil_Deserializes_To_Null()
+    {
+        var json = """
+            {
+                "identifierNetworkOperator": 9900987654321,
+                "executionTimeFrom": "2023-08-01T22:00:00Z",
+                "executionTimeUntil": null
+            }
+            """;
+        var model = JsonSerializer.Deserialize<MarketLocationNetworkOperator>(json);
+        model.Should().NotBeNull();
+        model!.ExecutionTimeUntil.Should().BeNull();
+        model
+            .ExecutionTimeFrom.Should()
+            .Be(new DateTimeOffset(2023, 8, 1, 22, 0, 0, TimeSpan.Zero));
+    }
+
+    [Fact]
+    public void Missing_ExecutionTimeUntil_Deserializes_To_Null()
+    {
+        var json = """
+            {
+                "identifierNetworkOperator": 9900987654321,
+                "executionTimeFrom": "2023-08-01T22:00:00Z"
+            }
+            """;
+        var model = JsonSerializer.Deserialize<MarketLocationNetworkOperator>(json);
+        model.Should().NotBeNull();
+        model!.ExecutionTimeUntil.Should().BeNull();
+    }
+
+    [Fact]
+    public void Unknown_EnergyDirection_Throws_JsonException()
+    {
+        var json = """
+            {
+                "identificationDateTime": "2023-08-02T22:00:00Z",
+                "energyDirection": "unknownValue"
+            }
+            """;
+        var deserializing = () => JsonSerializer.Deserialize<IdentificationParameter>(json);
+        deserializing.Should().Throw<JsonException>();
+    }
+
+    [Fact]
+    public void Unknown_MarketLocationProperty_Throws_JsonException()
+    {
+        var json = """
+            {
+                "marketLocationProperty": "unknownValue",
+                "executionTimeFrom": "2023-08-01T22:00:00Z"
+            }
+            """;
+        var deserializing = () => JsonSerializer.Deserialize<MarketLocationCharacteristic>(json);
+        deserializing.Should().Throw<JsonException>();
+    }
+
+    [Fact]
+    public void Unknown_Proportion_Throws_JsonException()
+    {
+        var json = """
+            {
+                "identifierTranche": "57685676742",
+                "proportion": "unknownValue"
+            }
+            """;
+        var deserializing = () => JsonSerializer.Deserialize<Tranche>(json);
+        deserializing.Should().Throw<JsonException>();
+    }
+
+    [Fact]
+    public void Unknown_Zone_Throws_JsonException()
+    {
+        var json = """
+            {
+                "latitude": "52.52",
+                "zone": "UTMZone99"
+            }
+            """;
+        var deserializing = () => JsonSerializer.Deserialize<GeographicCoordinates>(json);
+        deserializing.Should().Throw<JsonException>();
+    }
+}

--- a/MaLoIdentModels/MaLoIdentModelsTests/v2Tests/DateTimeOffsetDeserializationTests.cs
+++ b/MaLoIdentModels/MaLoIdentModelsTests/v2Tests/DateTimeOffsetDeserializationTests.cs
@@ -1,0 +1,120 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
+using AwesomeAssertions;
+using MaLoIdentModels.v2;
+
+namespace MaLoIdentModelsTests.v2Tests;
+
+public class DateTimeOffsetDeserializationTests
+{
+    [Theory]
+    [InlineData("2023-08-02T22:00:00")]
+    [InlineData("2023-08-02T22:00:00+17:99")]
+    public void Deserializing_An_DatetimeOffset_Without_Explicit_Offset_Throws_JsonException(
+        string invalidDateTimeOffsetString
+    )
+    {
+        var fileBody = File.ReadAllText("v2Tests/examples/request.json");
+        fileBody
+            .Should()
+            .Contain(
+                "\"2023-08-02T22:00:00Z\"",
+                because: "The original example data use trailing 'Z' to indicate UTC offset 0"
+            );
+        var requestJsonWithoutExplicitUtcOffset = fileBody.Replace(
+            "\"2023-08-02T22:00:00Z\"",
+            $"\"{invalidDateTimeOffsetString}\""
+        );
+        var deserializing = () =>
+            JsonSerializer.Deserialize<IdentificationParameter>(
+                requestJsonWithoutExplicitUtcOffset
+            );
+        deserializing.Should().Throw<JsonException>();
+    }
+
+    [Theory]
+    [InlineData("2023-08-02T22:00:00Z")]
+    [InlineData("2023-08-02T22:00:00+00:00")]
+    [InlineData("2023-08-03T00:00:00+02:00")]
+    [InlineData("2023-08-02T20:00:00-02:00")]
+    [InlineData("2023-08-03T00:00:00.000+02:00")]
+    [InlineData("2023-08-03T00:00:00.000000+02:00")]
+    public void Deserializing_An_DatetimeOffset_With_Explicit_Offset_Works(
+        string dateTimeOffsetString
+    )
+    {
+        var fileBody = File.ReadAllText("v2Tests/examples/request.json");
+        fileBody
+            .Should()
+            .Contain(
+                "\"2023-08-02T22:00:00Z\"",
+                because: "The original example data use trailing 'Z' to indicate UTC offset 0"
+            );
+        var requestJsonWithoutExplicitUtcOffset = fileBody.Replace(
+            "\"2023-08-02T22:00:00Z\"",
+            $"\"{dateTimeOffsetString}\""
+        );
+        var deserializing = () =>
+            JsonSerializer.Deserialize<IdentificationParameter>(
+                requestJsonWithoutExplicitUtcOffset
+            );
+        deserializing
+            .Should()
+            .NotThrow<JsonException>()
+            .And.Subject.Invoke()
+            .IdentificationDateTime.Should()
+            .Be(new DateTimeOffset(2023, 8, 2, 22, 0, 0, 0, TimeSpan.Zero));
+    }
+
+    [Theory]
+    [InlineData("2025-01-01T00:00:00Z", false)]
+    [InlineData("2024-12-31T23:00:00Z", true)]
+    [InlineData("2025-06-30T22:00:00Z", true)]
+    [InlineData("2025-06-30T23:00:00Z", false)]
+    public void Validation_Of_German_Midnight_Works(
+        string dateTimeOffsetString,
+        bool isValidExpected
+    )
+    {
+        var parameter = new IdentificationParameter
+        {
+            IdentificationDateTime = DateTimeOffset.Parse(dateTimeOffsetString),
+        };
+        var context = new ValidationContext(parameter);
+        var results = new List<ValidationResult>();
+        var isValidActual = Validator.TryValidateObject(parameter, context, results, true);
+        isValidActual.Should().Be(isValidExpected);
+    }
+
+    [Fact]
+    public void Serialization_Strips_SubSecond_Precision()
+    {
+        var fileBody = File.ReadAllText("v2Tests/examples/request.json");
+        var identificationParameter = JsonSerializer.Deserialize<IdentificationParameter>(fileBody);
+        identificationParameter.Should().NotBeNull();
+        while (
+            identificationParameter.IdentificationDateTime.Ticks == 0
+            || identificationParameter.IdentificationDateTime.Microsecond == 0
+        )
+        {
+            identificationParameter.IdentificationDateTime = DateTimeOffset.UtcNow;
+        }
+
+        identificationParameter.IdentificationDateTime.Ticks.Should().NotBe(0);
+        identificationParameter.IdentificationDateTime.Microsecond.Should().NotBe(0);
+        var serialized = JsonSerializer.Serialize(identificationParameter);
+        var strippedIdentificationDateTime = new DateTimeOffset(
+            identificationParameter.IdentificationDateTime.Year,
+            identificationParameter.IdentificationDateTime.Month,
+            identificationParameter.IdentificationDateTime.Day,
+            identificationParameter.IdentificationDateTime.Hour,
+            identificationParameter.IdentificationDateTime.Minute,
+            identificationParameter.IdentificationDateTime.Second,
+            TimeSpan.Zero
+        );
+        var strippedIdentificationDateTimeString = strippedIdentificationDateTime.ToString(
+            "yyyy-MM-ddTHH:mm:ssZ"
+        );
+        serialized.Should().Contain(strippedIdentificationDateTimeString);
+    }
+}

--- a/MaLoIdentModels/MaLoIdentModelsTests/v2Tests/EmptyStringAndObjectsDeserializationTests.cs
+++ b/MaLoIdentModels/MaLoIdentModelsTests/v2Tests/EmptyStringAndObjectsDeserializationTests.cs
@@ -1,0 +1,79 @@
+using System.Text.Json;
+using AwesomeAssertions;
+using MaLoIdentModels.v2;
+
+namespace MaLoIdentModelsTests.v2Tests;
+
+public class EmptyStringAndObjectsDeserializationTests
+{
+    [Fact]
+    public void Deserializing_Objects_With_Empty_Strings()
+    {
+        var fileBody = File.ReadAllText("v2Tests/examples/request_empty_string.json");
+        fileBody
+            .Should()
+            .Contain(
+                "\"\"",
+                because: "In the testdata an empty string is used to represent a missing value"
+            );
+        var deserializedModel = JsonSerializer.Deserialize<IdentificationParameter>(fileBody);
+        deserializedModel.Should().NotBeNull();
+        deserializedModel.IdentificationParameterId.Should().NotBeNull();
+        deserializedModel.IdentificationParameterAddress.Should().NotBeNull();
+        deserializedModel
+            .IdentificationParameterId.IdentifierMarketTranches.Should()
+            .BeNull(
+                because: "the field identifierMarketTranches is an empty list in the test data and should therefore be null after deserializing"
+            );
+        deserializedModel
+            .IdentificationParameterAddress.LandParcels.Should()
+            .BeNull(
+                because: "Landparcels should be null, because in the test data the fields of all objects in this list, are empty strings"
+            );
+        deserializedModel.IdentificationParameterAddress.GeographicCoordinates.Should().NotBeNull();
+        deserializedModel
+            .IdentificationParameterAddress.GeographicCoordinates.Easting.Should()
+            .BeNull(
+                because: "the fields of the geographic coordinates object should be null, because in the test data the fields are empty strings"
+            );
+        deserializedModel
+            .IdentificationParameterAddress.GeographicCoordinates.Northing.Should()
+            .BeNull(
+                because: "the fields of the geographic coordinates object should be null, because in the test data the fields are empty strings"
+            );
+        deserializedModel
+            .IdentificationParameterAddress.GeographicCoordinates.East.Should()
+            .BeNull(
+                because: "the fields of the geographic coordinates object should be null, because in the test data the fields are empty strings"
+            );
+        deserializedModel
+            .IdentificationParameterAddress.GeographicCoordinates.North.Should()
+            .BeNull(
+                "the fields of the geographic coordinates object should be null, because in the test data the fields are empty strings"
+            );
+        deserializedModel.IdentificationParameterAddress.LandParcels.Should().BeNull();
+    }
+
+    [Fact]
+    public void Deserializing_Pos_Response_Objects_With_Empty_Strings()
+    {
+        var fileBody = File.ReadAllText("v2Tests/examples/result_positive_empty_lists.json");
+        var deserializedModel = JsonSerializer.Deserialize<ResultPositive>(fileBody);
+        deserializedModel.Should().NotBeNull();
+        deserializedModel.MarketLocation.Should().NotBeNull();
+        deserializedModel
+            .MarketLocation.LandParcels.Should()
+            .BeNull(because: "this list contains one object, that has only empty string fields");
+        deserializedModel.MarketLocation.GeographicCoordinates.Should().NotBeNull();
+        deserializedModel
+            .MarketLocation.GeographicCoordinates.East.Should()
+            .BeNull(because: "field is empty string");
+        deserializedModel
+            .MarketLocation.GeographicCoordinates.North.Should()
+            .BeNull(because: "field is empty string");
+        deserializedModel.Tranches.Should().BeNull(because: "this list is empty");
+        deserializedModel.MeterLocations.Should().BeNull(because: "this list is empty");
+        deserializedModel.TechnicalResources.Should().BeNull(because: "this list is empty");
+        deserializedModel.ControllableResources.Should().BeNull(because: "this list is empty");
+    }
+}

--- a/MaLoIdentModels/MaLoIdentModelsTests/v2Tests/MarketLocationDateTimeTests.cs
+++ b/MaLoIdentModels/MaLoIdentModelsTests/v2Tests/MarketLocationDateTimeTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Text.Json;
+using AwesomeAssertions;
+using MaLoIdentModels.v2;
+
+namespace MaLoIdentModelsTests.v2Tests;
+
+public class MarketLocationDateTimeTests
+{
+    [Fact]
+    public void Deserializes_With_V2_Property_Names()
+    {
+        var json = """
+            {
+                "identifierMarketLocation": "57685676748",
+                "executionTimeFrom": "2023-08-01T22:00:00Z",
+                "executionTimeUntil": "2024-01-01T23:00:00Z"
+            }
+            """;
+        var model = JsonSerializer.Deserialize<MarketLocationDateTime>(json);
+        model.Should().NotBeNull();
+        model!.IdentifierMarketLocation.Should().Be("57685676748");
+        model
+            .ExecutionTimeFrom.Should()
+            .Be(new DateTimeOffset(2023, 8, 1, 22, 0, 0, TimeSpan.Zero));
+        model
+            .ExecutionTimeUntil.Should()
+            .Be(new DateTimeOffset(2024, 1, 1, 23, 0, 0, TimeSpan.Zero));
+    }
+
+    [Fact]
+    public void Serializes_With_V2_Property_Names()
+    {
+        var model = new MarketLocationDateTime
+        {
+            IdentifierMarketLocation = "57685676748",
+            ExecutionTimeFrom = new DateTimeOffset(2023, 8, 1, 22, 0, 0, TimeSpan.Zero),
+            ExecutionTimeUntil = new DateTimeOffset(2024, 1, 1, 23, 0, 0, TimeSpan.Zero),
+        };
+        var json = JsonSerializer.Serialize(model);
+        json.Should().Contain("\"identifierMarketLocation\"");
+        json.Should().NotContain("\"maloId\"");
+    }
+
+    [Fact]
+    public void Roundtrip_Preserves_Values()
+    {
+        var model = new MarketLocationDateTime
+        {
+            IdentifierMarketLocation = "57685676748",
+            ExecutionTimeFrom = new DateTimeOffset(2023, 8, 1, 22, 0, 0, TimeSpan.Zero),
+            ExecutionTimeUntil = null,
+        };
+        var json = JsonSerializer.Serialize(model);
+        var deserialized = JsonSerializer.Deserialize<MarketLocationDateTime>(json);
+        deserialized.Should().BeEquivalentTo(model);
+    }
+
+    [Fact]
+    public void Null_ExecutionTimeUntil_Roundtrips()
+    {
+        var json = """
+            {
+                "identifierMarketLocation": "57685676748",
+                "executionTimeFrom": "2023-08-01T22:00:00Z",
+                "executionTimeUntil": null
+            }
+            """;
+        var model = JsonSerializer.Deserialize<MarketLocationDateTime>(json);
+        model.Should().NotBeNull();
+        model!.ExecutionTimeUntil.Should().BeNull();
+        var reSerialized = JsonSerializer.Serialize(model);
+        reSerialized.Should().Contain("\"executionTimeUntil\":null");
+    }
+}

--- a/MaLoIdentModels/MaLoIdentModelsTests/v2Tests/PercentLessHundredConverterTests.cs
+++ b/MaLoIdentModels/MaLoIdentModelsTests/v2Tests/PercentLessHundredConverterTests.cs
@@ -71,4 +71,71 @@ public class PercentLessHundredConverterTests
         var deserialized = JsonSerializer.Deserialize<ModelWithPercent>(json);
         deserialized!.Percent.Should().Be(input);
     }
+
+    [Fact]
+    public void Deserializes_Empty_String_To_Null()
+    {
+        var json = "{\"percent\":\"\"}";
+        var model = JsonSerializer.Deserialize<ModelWithPercent>(json);
+        model.Should().NotBeNull();
+        model!.Percent.Should().BeNull();
+    }
+
+    [Fact]
+    public void Deserializes_Whitespace_String_To_Null()
+    {
+        var json = "{\"percent\":\"  \"}";
+        var model = JsonSerializer.Deserialize<ModelWithPercent>(json);
+        model.Should().NotBeNull();
+        model!.Percent.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("\"0.0\"", 0.0)]
+    [InlineData("\"00\"", 0)]
+    [InlineData("\"0.100\"", 0.100)]
+    public void Deserializes_Non_Canonical_Strings(string jsonValue, decimal expected)
+    {
+        var json = $"{{\"percent\":{jsonValue}}}";
+        var model = JsonSerializer.Deserialize<ModelWithPercent>(json);
+        model.Should().NotBeNull();
+        model!.Percent.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(100)]
+    [InlineData(100.001)]
+    [InlineData(999)]
+    public void Serialize_Throws_On_Value_Gte_100(decimal value)
+    {
+        var model = new ModelWithPercent { Percent = value };
+        var serializing = () => JsonSerializer.Serialize(model);
+        serializing.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void Serialize_Throws_On_Negative_Value()
+    {
+        var model = new ModelWithPercent { Percent = -1m };
+        var serializing = () => JsonSerializer.Serialize(model);
+        serializing.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void Serialize_Rounds_To_Three_Decimal_Places()
+    {
+        // 99.9999 rounds to 100.000 which should throw
+        var model = new ModelWithPercent { Percent = 99.9999m };
+        var serializing = () => JsonSerializer.Serialize(model);
+        serializing.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void Serialize_Value_That_Rounds_Down_Stays_Valid()
+    {
+        // 99.9994 rounds to 99.999 which is valid
+        var model = new ModelWithPercent { Percent = 99.9994m };
+        var json = JsonSerializer.Serialize(model);
+        json.Should().Contain("\"99.999\"");
+    }
 }

--- a/MaLoIdentModels/MaLoIdentModelsTests/v2Tests/PercentLessHundredConverterTests.cs
+++ b/MaLoIdentModels/MaLoIdentModelsTests/v2Tests/PercentLessHundredConverterTests.cs
@@ -1,0 +1,74 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using AwesomeAssertions;
+using MaLoIdentModels.JsonSettings;
+
+namespace MaLoIdentModelsTests.v2Tests;
+
+public class PercentLessHundredConverterTests
+{
+    private class ModelWithPercent
+    {
+        [JsonConverter(typeof(PercentLessHundredConverter))]
+        [JsonPropertyName("percent")]
+        public decimal? Percent { get; set; }
+    }
+
+    [Theory]
+    [InlineData(75.912, "\"75.912\"")]
+    [InlineData(0, "\"0\"")]
+    [InlineData(50.1, "\"50.1\"")]
+    [InlineData(99.999, "\"99.999\"")]
+    [InlineData(1, "\"1\"")]
+    public void Serializes_Decimal_To_String(decimal input, string expectedJsonValue)
+    {
+        var model = new ModelWithPercent { Percent = input };
+        var json = JsonSerializer.Serialize(model);
+        json.Should().Contain($"\"percent\":{expectedJsonValue}");
+    }
+
+    [Fact]
+    public void Serializes_Null_To_Null()
+    {
+        var model = new ModelWithPercent { Percent = null };
+        var json = JsonSerializer.Serialize(model);
+        json.Should().Contain("\"percent\":null");
+    }
+
+    [Theory]
+    [InlineData("\"75.912\"", 75.912)]
+    [InlineData("\"0\"", 0)]
+    [InlineData("\"50.1\"", 50.1)]
+    [InlineData("\"99.999\"", 99.999)]
+    public void Deserializes_String_To_Decimal(string jsonValue, decimal expected)
+    {
+        var json = $"{{\"percent\":{jsonValue}}}";
+        var model = JsonSerializer.Deserialize<ModelWithPercent>(json);
+        model.Should().NotBeNull();
+        model!.Percent.Should().Be(expected);
+    }
+
+    [Fact]
+    public void Deserializes_Null_To_Null()
+    {
+        var json = "{\"percent\":null}";
+        var model = JsonSerializer.Deserialize<ModelWithPercent>(json);
+        model.Should().NotBeNull();
+        model!.Percent.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(75.912, "75.912")]
+    [InlineData(75.9, "75.9")]
+    [InlineData(75.91, "75.91")]
+    [InlineData(0, "0")]
+    [InlineData(99.999, "99.999")]
+    public void Roundtrip_Preserves_Value(decimal input, string expectedStringInJson)
+    {
+        var model = new ModelWithPercent { Percent = input };
+        var json = JsonSerializer.Serialize(model);
+        json.Should().Contain($"\"{expectedStringInJson}\"");
+        var deserialized = JsonSerializer.Deserialize<ModelWithPercent>(json);
+        deserialized!.Percent.Should().Be(input);
+    }
+}

--- a/MaLoIdentModels/MaLoIdentModelsTests/v2Tests/PercentLessHundredValidationTests.cs
+++ b/MaLoIdentModels/MaLoIdentModelsTests/v2Tests/PercentLessHundredValidationTests.cs
@@ -1,0 +1,69 @@
+using System.ComponentModel.DataAnnotations;
+using AwesomeAssertions;
+using MaLoIdentModels.Validation;
+
+namespace MaLoIdentModelsTests.v2Tests;
+
+public class PercentLessHundredValidationTests
+{
+    private class ModelWithPercent
+    {
+        [PercentLessHundredValidation]
+        public decimal? Percent { get; set; }
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(50)]
+    [InlineData(75.912)]
+    [InlineData(99.999)]
+    [InlineData(99)]
+    [InlineData(0.1)]
+    [InlineData(0.001)]
+    public void Valid_Percentages_Pass_Validation(decimal value)
+    {
+        var model = new ModelWithPercent { Percent = value };
+        var context = new ValidationContext(model);
+        var results = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(model, context, results, true);
+        isValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Null_Passes_Validation()
+    {
+        var model = new ModelWithPercent { Percent = null };
+        var context = new ValidationContext(model);
+        var results = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(model, context, results, true);
+        isValid.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(100)]
+    [InlineData(100.001)]
+    [InlineData(-1)]
+    [InlineData(-0.001)]
+    [InlineData(999)]
+    public void Invalid_Percentages_Fail_Validation(decimal value)
+    {
+        var model = new ModelWithPercent { Percent = value };
+        var context = new ValidationContext(model);
+        var results = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(model, context, results, true);
+        isValid.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(99.9999)]
+    [InlineData(0.0001)]
+    [InlineData(50.12345)]
+    public void Too_Many_Decimal_Places_Fail_Validation(decimal value)
+    {
+        var model = new ModelWithPercent { Percent = value };
+        var context = new ValidationContext(model);
+        var results = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(model, context, results, true);
+        isValid.Should().BeFalse();
+    }
+}

--- a/MaLoIdentModels/MaLoIdentModelsTests/v2Tests/RoundTripTests.cs
+++ b/MaLoIdentModels/MaLoIdentModelsTests/v2Tests/RoundTripTests.cs
@@ -1,0 +1,64 @@
+using AwesomeAssertions;
+using MaLoIdentModels.v2;
+
+namespace MaLoIdentModelsTests.v2Tests;
+
+public class RoundTripTests
+{
+    [Fact]
+    public void Test_Request()
+    {
+        var fileBody = File.ReadAllText("v2Tests/examples/request.json");
+        var model = System.Text.Json.JsonSerializer.Deserialize<IdentificationParameter>(fileBody);
+        model.Should().NotBeNull();
+        model!.IdentificationDateTime.Offset.Should().Be(TimeSpan.Zero);
+        var reSerialized = System.Text.Json.JsonSerializer.Serialize(model);
+        Utilities.AssertJsonStringsAreEquivalent(fileBody, reSerialized);
+        var deserialized = System.Text.Json.JsonSerializer.Deserialize<IdentificationParameter>(
+            reSerialized
+        );
+        deserialized.Should().BeEquivalentTo(model);
+    }
+
+    [Fact]
+    public void Test_Positive_Result()
+    {
+        var fileBody = File.ReadAllText("v2Tests/examples/result_positive.json");
+        var model = System.Text.Json.JsonSerializer.Deserialize<ResultPositive>(fileBody);
+        model.Should().NotBeNull();
+        var reSerialized = System.Text.Json.JsonSerializer.Serialize(model);
+        Utilities.AssertJsonStringsAreEquivalent(reSerialized, fileBody);
+        var deserialized = System.Text.Json.JsonSerializer.Deserialize<ResultPositive>(
+            reSerialized
+        );
+        deserialized.Should().BeEquivalentTo(model);
+    }
+
+    [Fact]
+    public void Test_Negative_Result()
+    {
+        var fileBody = File.ReadAllText("v2Tests/examples/result_negative.json");
+        var model = System.Text.Json.JsonSerializer.Deserialize<ResultNegative>(fileBody);
+        model.Should().NotBeNull();
+        var reSerialized = System.Text.Json.JsonSerializer.Serialize(model);
+        Utilities.AssertJsonStringsAreEquivalent(reSerialized, fileBody);
+        var deserialized = System.Text.Json.JsonSerializer.Deserialize<ResultNegative>(
+            reSerialized
+        );
+        deserialized.Should().BeEquivalentTo(model);
+    }
+
+    [Fact]
+    public void Test_README_Example()
+    {
+        var myNegativeResponse = new ResultNegative
+        {
+            DecisionTree = "E_0594",
+            ResponseCode = "A10",
+            Reason = "Ich bin ein Freitext.",
+            IdentifierNetworkOperator = 9900987654321,
+        };
+        var myJson = System.Text.Json.JsonSerializer.Serialize(myNegativeResponse);
+        Console.Out.WriteLine(myJson);
+    }
+}

--- a/MaLoIdentModels/MaLoIdentModelsTests/v2Tests/RoundTripTests.cs
+++ b/MaLoIdentModels/MaLoIdentModelsTests/v2Tests/RoundTripTests.cs
@@ -56,7 +56,7 @@ public class RoundTripTests
             DecisionTree = "E_0594",
             ResponseCode = "A10",
             Reason = "Ich bin ein Freitext.",
-            IdentifierNetworkOperator = 9900987654321,
+            IdentifierNetworkOperator = "9900987654321",
         };
         var myJson = System.Text.Json.JsonSerializer.Serialize(myNegativeResponse);
         Console.Out.WriteLine(myJson);

--- a/MaLoIdentModels/MaLoIdentModelsTests/v2Tests/examples/request.json
+++ b/MaLoIdentModels/MaLoIdentModelsTests/v2Tests/examples/request.json
@@ -1,0 +1,43 @@
+{
+  "identificationDateTime": "2023-08-02T22:00:00Z",
+  "energyDirection": "consumption",
+  "identificationParameterId": {
+    "identifierMarketLocation": "57685676748",
+    "identifierMarketTranches": ["57685676742"],
+    "identifierMeterLocations": ["DE00014545768S0000000000000003054"],
+    "meterNumbers": ["1SM-8465929523"],
+    "customerNumber": "V567345345"
+  },
+  "identificationParameterAddress": {
+    "name": {
+      "surnames": "Becker",
+      "firstnames": "Michael",
+      "title": "Prof.Dr.",
+      "company": "BDEW & Co. KG"
+    },
+    "address": {
+      "countryCode": "DE",
+      "zipCode": "12117",
+      "city": "Berlin",
+      "street": "Reinhardtstraße",
+      "houseNumber": 32,
+      "houseNumberAddition": "F"
+    },
+    "landParcels": [
+      {
+        "districtName": "string",
+        "lotNumber": "string",
+        "subLotNumber": "string"
+      }
+    ],
+    "geographicCoordinates": {
+      "latitude": "string",
+      "longitude": "string",
+      "east": "string",
+      "north": "string",
+      "zone": "UTMZone31",
+      "northing": "string",
+      "easting": "string"
+    }
+  }
+}

--- a/MaLoIdentModels/MaLoIdentModelsTests/v2Tests/examples/request_empty_string.json
+++ b/MaLoIdentModels/MaLoIdentModelsTests/v2Tests/examples/request_empty_string.json
@@ -1,0 +1,43 @@
+{
+  "identificationDateTime": "2023-08-02T22:00:00Z",
+  "energyDirection": "consumption",
+  "identificationParameterId": {
+    "identifierMarketLocation": "57685676748",
+    "identifierMarketTranches": [],
+    "identifierMeterLocations": ["DE00014545768S0000000000000003054"],
+    "meterNumbers": ["1SM-8465929523"],
+    "customerNumber": "V567345345"
+  },
+  "identificationParameterAddress": {
+    "name": {
+      "surnames": "Becker",
+      "firstnames": "Michael",
+      "title": "Prof.Dr.",
+      "company": "BDEW & Co. KG"
+    },
+    "address": {
+      "countryCode": "DE",
+      "zipCode": "12117",
+      "city": "Berlin",
+      "street": "Reinhardtstraße",
+      "houseNumber": 32,
+      "houseNumberAddition": "F"
+    },
+    "landParcels": [
+      {
+        "districtName": "",
+        "lotNumber": "",
+        "subLotNumber": ""
+      }
+    ],
+    "geographicCoordinates": {
+      "latitude": "string",
+      "longitude": "string",
+      "east": "",
+      "north": "",
+      "zone": "UTMZone31",
+      "northing": "",
+      "easting": ""
+    }
+  }
+}

--- a/MaLoIdentModels/MaLoIdentModelsTests/v2Tests/examples/result_negative.json
+++ b/MaLoIdentModels/MaLoIdentModelsTests/v2Tests/examples/result_negative.json
@@ -1,0 +1,6 @@
+{
+  "decisionTree": "E_0594",
+  "responseCode": "A10",
+  "reason": "Ich bin ein Freitext.",
+  "identifierNetworkOperator": 9900987654321
+}

--- a/MaLoIdentModels/MaLoIdentModelsTests/v2Tests/examples/result_negative.json
+++ b/MaLoIdentModels/MaLoIdentModelsTests/v2Tests/examples/result_negative.json
@@ -2,5 +2,5 @@
   "decisionTree": "E_0594",
   "responseCode": "A10",
   "reason": "Ich bin ein Freitext.",
-  "identifierNetworkOperator": 9900987654321
+  "identifierNetworkOperator": "9900987654321"
 }

--- a/MaLoIdentModels/MaLoIdentModelsTests/v2Tests/examples/result_positive.json
+++ b/MaLoIdentModels/MaLoIdentModelsTests/v2Tests/examples/result_positive.json
@@ -1,0 +1,128 @@
+{
+  "marketLocation": {
+    "identifierMarketLocation": "57685676748",
+    "energyDirection": "consumption",
+    "measurementTechnologyClassification": "intelligentMeasuringSystem",
+    "characteristics": [
+      {
+        "marketLocationProperty": "standard",
+        "executionTimeFrom": "2023-08-01T22:00:00Z",
+        "executionTimeUntil": "2023-08-01T22:00:00Z"
+      }
+    ],
+    "networkOperators": [
+      {
+        "identifierNetworkOperator": 9900987654321,
+        "executionTimeFrom": "2023-08-01T22:00:00Z",
+        "executionTimeUntil": "2023-08-01T22:00:00Z"
+      }
+    ],
+    "measuringPointOperators": [
+      {
+        "identifierMeasuringPointOperator": 9900987654321,
+        "executionTimeFrom": "2023-08-01T22:00:00Z",
+        "executionTimeUntil": "2023-08-01T22:00:00Z"
+      }
+    ],
+    "transmissionSystemOperators": [
+      {
+        "identifierTransmissionSystemOperator": 9900987654321,
+        "executionTimeFrom": "2023-08-01T22:00:00Z",
+        "executionTimeUntil": "2023-08-01T22:00:00Z"
+      }
+    ],
+    "suppliers": [
+      {
+        "identifierSupplier": 9900987654321,
+        "executionTimeFrom": "2023-08-01T22:00:00Z",
+        "executionTimeUntil": "2023-08-01T22:00:00Z"
+      }
+    ],
+    "name": {
+      "surnames": "Becker",
+      "firstnames": "Michael",
+      "title": "Prof.Dr.",
+      "company": "BDEW & Co. KG"
+    },
+    "address": {
+      "countryCode": "DE",
+      "zipCode": "12117",
+      "city": "Berlin",
+      "street": "Reinhardtstraße",
+      "houseNumber": 32,
+      "houseNumberAddition": "F"
+    },
+    "landParcels": [
+      {
+        "districtName": "string",
+        "lotNumber": "string",
+        "subLotNumber": "string"
+      }
+    ],
+    "geographicCoordinates": {
+      "latitude": "string",
+      "longitude": "string",
+      "east": "string",
+      "north": "string",
+      "zone": "UTMZone31",
+      "northing": "string",
+      "easting": "string"
+    }
+  },
+  "tranches": [
+    {
+      "identifierTranche": "57685676742",
+      "proportion": "percent",
+      "percentLessHundred": "75.912",
+      "trancheSuppliers": [
+        {
+          "identifierSupplier": 9900987654321,
+          "executionTimeFrom": "2023-08-01T22:00:00Z",
+          "executionTimeUntil": "2023-08-01T22:00:00Z"
+        }
+      ]
+    }
+  ],
+  "meterLocations": [
+    {
+      "identifierMeterLocation": "DE00014545768S0000000000000003054",
+      "meterNumber": "1SM-8465929523",
+      "meterLocationMeasuringPointOperators": [
+        {
+          "identifierMeasuringPointOperator": 9900987654321,
+          "executionTimeFrom": "2023-08-01T22:00:00Z",
+          "executionTimeUntil": "2023-08-01T22:00:00Z"
+        }
+      ]
+    }
+  ],
+  "technicalResources": [
+    {
+      "identifierTechnicalResource": "D1234848431"
+    }
+  ],
+  "controllableResources": [
+    {
+      "identifierControllableRessource": "C1234848431",
+      "controllableResourceMeasuringPointOperators": [
+        {
+          "identifierMeasuringPointOperator": 9900987654321,
+          "executionTimeFrom": "2023-08-01T22:00:00Z",
+          "executionTimeUntil": "2023-08-01T22:00:00Z"
+        }
+      ]
+    }
+  ],
+  "networkLocations": [
+    {
+      "identifierNetworkLocation": "E1234848431",
+      "networkLocationMeasuringPointOperators": [
+        {
+          "identifierMeasuringPointOperator": 9900987654321,
+          "executionTimeFrom": "2023-08-01T22:00:00Z",
+          "executionTimeUntil": "2023-08-01T22:00:00Z"
+        }
+      ]
+    }
+  ]
+}

--- a/MaLoIdentModels/MaLoIdentModelsTests/v2Tests/examples/result_positive.json
+++ b/MaLoIdentModels/MaLoIdentModelsTests/v2Tests/examples/result_positive.json
@@ -12,28 +12,28 @@
     ],
     "networkOperators": [
       {
-        "identifierNetworkOperator": 9900987654321,
+        "identifierNetworkOperator": "9900987654321",
         "executionTimeFrom": "2023-08-01T22:00:00Z",
         "executionTimeUntil": "2023-08-01T22:00:00Z"
       }
     ],
     "measuringPointOperators": [
       {
-        "identifierMeasuringPointOperator": 9900987654321,
+        "identifierMeasuringPointOperator": "9900987654321",
         "executionTimeFrom": "2023-08-01T22:00:00Z",
         "executionTimeUntil": "2023-08-01T22:00:00Z"
       }
     ],
     "transmissionSystemOperators": [
       {
-        "identifierTransmissionSystemOperator": 9900987654321,
+        "identifierTransmissionSystemOperator": "9900987654321",
         "executionTimeFrom": "2023-08-01T22:00:00Z",
         "executionTimeUntil": "2023-08-01T22:00:00Z"
       }
     ],
     "suppliers": [
       {
-        "identifierSupplier": 9900987654321,
+        "identifierSupplier": "9900987654321",
         "executionTimeFrom": "2023-08-01T22:00:00Z",
         "executionTimeUntil": "2023-08-01T22:00:00Z"
       }
@@ -76,7 +76,7 @@
       "percentLessHundred": "75.912",
       "trancheSuppliers": [
         {
-          "identifierSupplier": 9900987654321,
+          "identifierSupplier": "9900987654321",
           "executionTimeFrom": "2023-08-01T22:00:00Z",
           "executionTimeUntil": "2023-08-01T22:00:00Z"
         }
@@ -89,7 +89,7 @@
       "meterNumber": "1SM-8465929523",
       "meterLocationMeasuringPointOperators": [
         {
-          "identifierMeasuringPointOperator": 9900987654321,
+          "identifierMeasuringPointOperator": "9900987654321",
           "executionTimeFrom": "2023-08-01T22:00:00Z",
           "executionTimeUntil": "2023-08-01T22:00:00Z"
         }
@@ -106,7 +106,7 @@
       "identifierControllableRessource": "C1234848431",
       "controllableResourceMeasuringPointOperators": [
         {
-          "identifierMeasuringPointOperator": 9900987654321,
+          "identifierMeasuringPointOperator": "9900987654321",
           "executionTimeFrom": "2023-08-01T22:00:00Z",
           "executionTimeUntil": "2023-08-01T22:00:00Z"
         }
@@ -118,7 +118,7 @@
       "identifierNetworkLocation": "E1234848431",
       "networkLocationMeasuringPointOperators": [
         {
-          "identifierMeasuringPointOperator": 9900987654321,
+          "identifierMeasuringPointOperator": "9900987654321",
           "executionTimeFrom": "2023-08-01T22:00:00Z",
           "executionTimeUntil": "2023-08-01T22:00:00Z"
         }

--- a/MaLoIdentModels/MaLoIdentModelsTests/v2Tests/examples/result_positive_empty_lists.json
+++ b/MaLoIdentModels/MaLoIdentModelsTests/v2Tests/examples/result_positive_empty_lists.json
@@ -1,0 +1,88 @@
+{
+  "marketLocation": {
+    "identifierMarketLocation": "57685676748",
+    "energyDirection": "consumption",
+    "measurementTechnologyClassification": "intelligentMeasuringSystem",
+    "characteristics": [
+      {
+        "marketLocationProperty": "standard",
+        "executionTimeFrom": "2023-08-01T22:00:00Z",
+        "executionTimeUntil": "2023-08-01T22:00:00Z"
+      }
+    ],
+    "networkOperators": [
+      {
+        "identifierNetworkOperator": 9900987654321,
+        "executionTimeFrom": "2023-08-01T22:00:00Z",
+        "executionTimeUntil": "2023-08-01T22:00:00Z"
+      }
+    ],
+    "measuringPointOperators": [
+      {
+        "identifierMeasuringPointOperator": 9900987654321,
+        "executionTimeFrom": "2023-08-01T22:00:00Z",
+        "executionTimeUntil": "2023-08-01T22:00:00Z"
+      }
+    ],
+    "transmissionSystemOperators": [
+      {
+        "identifierTransmissionSystemOperator": 9900987654321,
+        "executionTimeFrom": "2023-08-01T22:00:00Z",
+        "executionTimeUntil": "2023-08-01T22:00:00Z"
+      }
+    ],
+    "suppliers": [
+      {
+        "identifierSupplier": 9900987654321,
+        "executionTimeFrom": "2023-08-01T22:00:00Z",
+        "executionTimeUntil": "2023-08-01T22:00:00Z"
+      }
+    ],
+    "name": {
+      "surnames": "Becker",
+      "firstnames": "Michael",
+      "title": "Prof.Dr.",
+      "company": "BDEW & Co. KG"
+    },
+    "address": {
+      "countryCode": "DE",
+      "zipCode": "12117",
+      "city": "Berlin",
+      "street": "Reinhardtstraße",
+      "houseNumber": 32,
+      "houseNumberAddition": "F"
+    },
+    "landParcels": [
+      {
+        "districtName": "",
+        "lotNumber": "",
+        "subLotNumber": ""
+      }
+    ],
+    "geographicCoordinates": {
+      "latitude": "string",
+      "longitude": "string",
+      "east": "",
+      "north": "",
+      "zone": "UTMZone31",
+      "northing": "string",
+      "easting": "string"
+    }
+  },
+  "tranches": [],
+  "meterLocations": [],
+  "technicalResources": [],
+  "controllableResources": [],
+  "networkLocations": [
+    {
+      "identifierNetworkLocation": "E1234848431",
+      "networkLocationMeasuringPointOperators": [
+        {
+          "identifierMeasuringPointOperator": 9900987654321,
+          "executionTimeFrom": "2023-08-01T22:00:00Z",
+          "executionTimeUntil": "2023-08-01T22:00:00Z"
+        }
+      ]
+    }
+  ]
+}

--- a/MaLoIdentModels/MaLoIdentModelsTests/v2Tests/examples/result_positive_empty_lists.json
+++ b/MaLoIdentModels/MaLoIdentModelsTests/v2Tests/examples/result_positive_empty_lists.json
@@ -12,28 +12,28 @@
     ],
     "networkOperators": [
       {
-        "identifierNetworkOperator": 9900987654321,
+        "identifierNetworkOperator": "9900987654321",
         "executionTimeFrom": "2023-08-01T22:00:00Z",
         "executionTimeUntil": "2023-08-01T22:00:00Z"
       }
     ],
     "measuringPointOperators": [
       {
-        "identifierMeasuringPointOperator": 9900987654321,
+        "identifierMeasuringPointOperator": "9900987654321",
         "executionTimeFrom": "2023-08-01T22:00:00Z",
         "executionTimeUntil": "2023-08-01T22:00:00Z"
       }
     ],
     "transmissionSystemOperators": [
       {
-        "identifierTransmissionSystemOperator": 9900987654321,
+        "identifierTransmissionSystemOperator": "9900987654321",
         "executionTimeFrom": "2023-08-01T22:00:00Z",
         "executionTimeUntil": "2023-08-01T22:00:00Z"
       }
     ],
     "suppliers": [
       {
-        "identifierSupplier": 9900987654321,
+        "identifierSupplier": "9900987654321",
         "executionTimeFrom": "2023-08-01T22:00:00Z",
         "executionTimeUntil": "2023-08-01T22:00:00Z"
       }
@@ -78,7 +78,7 @@
       "identifierNetworkLocation": "E1234848431",
       "networkLocationMeasuringPointOperators": [
         {
-          "identifierMeasuringPointOperator": 9900987654321,
+          "identifierMeasuringPointOperator": "9900987654321",
           "executionTimeFrom": "2023-08-01T22:00:00Z",
           "executionTimeUntil": "2023-08-01T22:00:00Z"
         }


### PR DESCRIPTION
                                                                                                                                       
  Here's the updated summary:                                                                                                                                                                                                    
                                                                                                                                                                                                                                 
  ## Summary                                                                                                                                                                                                                     
                                                                                                                                                                                                                                 
  Add `MaLoIdentModels.v2` namespace with C# models for the [EDI-Energy api-electricity 2.0.0](https://github.com/EDI-Energy/api-electricity/releases/tag/2.0.0) MaLo identification spec. Key differences from v1:              

  - Camel-case JSON property names (matching the v2 wire format) instead of PascalCase
  - New model structures: `IdentificationParameter` (request), `ResultPositive`/`ResultNegative` (response), with nested types for market locations, tranches, meter locations, network locations, controllable/technical
  resources
  - `MarketPartnerId` and `IdentifierNetworkOperator` typed as `string?` with `[RegularExpression(@"^\d{13}$")]` per spec (v1 uses `long`)
  - Enums serialized as camelCase strings (`EnergyDirection`, `Zone`, `Proportion`, `MarketLocationProperty`, `MeasurementTechnologyClassification`)
  - Nullable `DateTimeOffset?` for `ExecutionTimeUntil` with custom trailing-Z JSON converters
  - Bidirectional `<seealso>` cross-references between v1 and v2 types
  - Empty-string and empty-list handling: deserializes gracefully to `null`
  - 100 tests (roundtrip serialization, edge cases, empty strings) passing on net9.0 + net10.0

  ## Breaking changes

  None — v1 namespace is untouched. The v2 namespace is entirely additive.